### PR TITLE
Issue#226

### DIFF
--- a/base-foc/run/env
+++ b/base-foc/run/env
@@ -176,7 +176,7 @@ proc build_boot_image_arm {binaries} {
 	close $fh
 
 	set gen_img_cmd "cd [l4_dir]/source/pkg/bootstrap/server/src && "
-	append gen_img_cmd "make O=[l4_dir] ENTRY=genode "
+	append gen_img_cmd "make O=[l4_dir] E=genode "
 	append gen_img_cmd "BOOTSTRAP_DO_UIMAGE= BOOTSTRAP_DO_RAW_IMAGE= "
 	append gen_img_cmd "BOOTSTRAP_MODULES_LIST=[pwd]/[run_dir]/modules.list "
 	append gen_img_cmd "BOOTSTRAP_SEARCH_PATH=[pwd]/[run_dir]:[file dirname [fiasco]]:[l4_dir] "


### PR DESCRIPTION
When invoking the bootstrap build in the L4RE build-system to create
a single elf-image containing all needed files to boot a scenario, don't
use the 'ENTRY' variable, but 'E' variable instead. Otherwise 'ENTRY'
might get overridden (dependent on the make-version). Moreover, using
'E' seems to be the way L4Re is expecting it has to be invoked.
