### PR TITLE
chroot_loader: Fix run script for 64bit environment

### DIFF
--- a/os/run/chroot_loader.run
+++ b/os/run/chroot_loader.run
@@ -69,6 +69,7 @@ proc cleanup_chroot { } {
 		catch { exec sudo umount -l [chroot_cwd_path $id] }
 		catch { exec sudo umount -l [chroot_genode_tmp_path $id] }
 		catch { exec sudo umount -l [chroot_path $id]/lib }
+		catch { exec sudo umount -l [chroot_path $id]/lib64 }
 		catch { exec rm -rf [chroot_path $id] }
 	}
 }
@@ -107,9 +108,11 @@ cleanup_chroot
 foreach id { 1 2 } {
 	exec mkdir -p [chroot_path $id]
 	exec mkdir -p [chroot_path $id]/lib
+	exec mkdir -p [chroot_path $id]/lib64
 
 	# bind mount '/lib' as need libc within the chroot environment
 	exec sudo mount --bind /lib [chroot_path $id]/lib
+	catch { exec sudo mount --bind /lib64 [chroot_path $id]/lib64 }
 }
 
 #


### PR DESCRIPTION
The /lib64 path is required here to allow execution of 64bit binaries.

Here is an example-ldd call:

$ ldd /bin/ls
    linux-vdso.so.1 =>  (0x00007fffdedff000)
    libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007f4ae207d000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4ae1e75000)
    libacl.so.1 => /lib/x86_64-linux-gnu/libacl.so.1 (0x00007f4ae1c6c000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4ae18af000)
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4ae16ab000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f4ae22bd000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4ae148d000)
    libattr.so.1 => /lib/x86_64-linux-gnu/libattr.so.1 (0x00007f4ae1288000)
