### PR TITLE
loader: Qualify size_t usages

### DIFF
--- a/os/include/loader_session/client.h
+++ b/os/include/loader_session/client.h
@@ -26,13 +26,13 @@ namespace Loader {
 		explicit Session_client(Loader::Session_capability session)
 		: Rpc_client<Session>(session) { }
 
-		Dataspace_capability alloc_rom_module(Name const &name, size_t size) {
+		Dataspace_capability alloc_rom_module(Name const &name, Genode::size_t size) {
 			return call<Rpc_alloc_rom_module>(name, size); }
 
 		void commit_rom_module(Name const &name) {
 			call<Rpc_commit_rom_module>(name); }
 
-		void ram_quota(size_t quantum) {
+		void ram_quota(Genode::size_t quantum) {
 			call<Rpc_ram_quota>(quantum); }
 
 		void constrain_geometry(int width, int height) {

--- a/os/include/loader_session/connection.h
+++ b/os/include/loader_session/connection.h
@@ -22,7 +22,7 @@ namespace Loader {
 
 	struct Connection : Genode::Connection<Session>, Session_client
 	{
-		Connection(size_t ram_quota)
+		Connection(Genode::size_t ram_quota)
 		:
 			Genode::Connection<Session>(session("ram_quota=%zd", ram_quota)),
 			Session_client(cap())

--- a/os/include/loader_session/loader_session.h
+++ b/os/include/loader_session/loader_session.h
@@ -69,7 +69,7 @@ namespace Loader {
 		 * becomes visible. The server frees intermediate dataspaces that are
 		 * no longer used.
 		 */
-		virtual Dataspace_capability alloc_rom_module(Name const &name, size_t size) = 0;
+		virtual Dataspace_capability alloc_rom_module(Name const &name, Genode::size_t size) = 0;
 
 		/**
 		 * Expose ROM module to loaded subsystem
@@ -91,7 +91,7 @@ namespace Loader {
 		 * If 'ram_quota' is not called prior calling 'start', all available
 		 * session resources will be assigned to the subsystem.
 		 */
-		virtual void ram_quota(size_t quantum) = 0;
+		virtual void ram_quota(Genode::size_t quantum) = 0;
 
 		/**
 		 * Constrain size of the nitpicker buffer used by the subsystem
@@ -134,11 +134,11 @@ namespace Loader {
 		 *******************/
 
 		GENODE_RPC(Rpc_alloc_rom_module, Dataspace_capability, alloc_rom_module,
-		                                 Name const &, size_t);
+			   Name const &, Genode::size_t);
 		GENODE_RPC_THROW(Rpc_commit_rom_module, void, commit_rom_module,
 		                 GENODE_TYPE_LIST(Rom_module_does_not_exist),
 		                 Name const &);
-		GENODE_RPC(Rpc_ram_quota, void, ram_quota, size_t);
+		GENODE_RPC(Rpc_ram_quota, void, ram_quota, Genode::size_t);
 		GENODE_RPC(Rpc_constrain_geometry, void, constrain_geometry, int, int);
 		GENODE_RPC(Rpc_view_ready_sigh, void, view_ready_sigh, Signal_context_capability);
 		GENODE_RPC_THROW(Rpc_start, void, start,


### PR DESCRIPTION
The compiler complained about ambigous references when compiling a
lx_hybrid program using the loader session.  Here are some error
messages:

genode/os/include/loader_session/loader_session.h:72: error: reference to 'size_t' is ambiguous
/usr/lib/gcc/i486-linux-gnu/4.4.5/include/stddef.h:211: error: candidates are: typedef unsigned int size_t
genode/base/include/base/stdint.h:25: error:                 typedef unsigned int Genode::size_t
genode/os/include/loader_session/loader_session.h:72: error: reference to 'size_t' is ambiguous
/usr/lib/gcc/i486-linux-gnu/4.4.5/include/stddef.h:211: error: candidates are: typedef unsigned int size_t
genode/base/include/base/stdint.h:25: error:                 typedef unsigned int Genode::size_t
...

This commit qualifies size_t using the Genode namespace which fixes
the compilation.
