### PR TITLE
loader_session: Fixes some g++ warnings about uninitialized variable

### DIFF
--- a/os/include/loader_session/loader_session.h
+++ b/os/include/loader_session/loader_session.h
@@ -48,6 +48,9 @@ namespace Loader {
 		{
 			int width, height;
 			int buf_x, buf_y;
+
+			View_geometry(): width(0), height(0), buf_x(0), buf_y() {}
+			View_geometry(int w, int h, int x, int y): width(w), height(h), buf_x(x), buf_y(y) {}
 		};
 
 		typedef Genode::Rpc_in_buffer<64>  Name;

--- a/os/src/server/loader/nitpicker.h
+++ b/os/src/server/loader/nitpicker.h
@@ -270,11 +270,11 @@ namespace Nitpicker {
 			 */
 			Loader::Session::View_geometry loader_view_geometry()
 			{
-				Loader::Session::View_geometry result = {
+				Loader::Session::View_geometry result(
 					min(_proxy_view.w(), _fb_width),
 					min(_proxy_view.h(), _fb_height),
 					_proxy_view.buf_x(),
-					_proxy_view.buf_y() };
+					_proxy_view.buf_y());
 
 				return result;
 			}


### PR DESCRIPTION
g++ 4.4.5 outputs the following warnings in our code using the loader
session:

.../base/include/base/capability.h: In member function 'typename Genode::Trait::Call_return<typename IF::Ret_type>::Type Genode::Capability<RPC_INTERFACE>::call() const [with IF = Loader::Session::Rpc_view_geometry, RPC_INTERFACE = Loader::Session]':
.../base/include/base/capability.h:207: warning: 'ret.Genode::CapabilityLoader::Session::ReturnLoader::Session::Rpc_view_geometry::_value.Loader::Session::View_geometry::width' may be used uninitialized in this function
.../base/include/base/capability.h:207: warning: 'ret.Genode::CapabilityLoader::Session::ReturnLoader::Session::Rpc_view_geometry::_value.Loader::Session::View_geometry::height' may be used uninitialized in this function
.../base/include/base/capability.h:207: warning: 'ret.Genode::CapabilityLoader::Session::ReturnLoader::Session::Rpc_view_geometry::_value.Loader::Session::View_geometry::buf_x' may be used uninitialized in this function
.../base/include/base/capability.h:207: warning: 'ret.Genode::CapabilityLoader::Session::ReturnLoader::Session::Rpc_view_geometry::_value.Loader::Session::View_geometry::buf_y' may be used uninitialized in this function

This is easily fixed with providing a default constructor.

Because of the C++ rules regarding initialer lists code that used
them for View_geometry had to be modified to use a normal construction
call.  In my tests only Nitpicker had to be changed.
