### PR TITLE
lx_hybrid: Set SIGIGN for SIGCHLD only for newly created processes

### DIFF
--- a/base-linux/src/platform/linux_syscalls.h
+++ b/base-linux/src/platform/linux_syscalls.h
@@ -410,6 +410,11 @@ inline int lx_create_thread(void (*entry)(void *), void *stack, void *arg)
 
 inline int lx_create_process(int (*entry)(void *), void *stack, void *arg)
 {
+	/*
+	 * Prevent children from becoming zombies. (SIG_IGN = 1)
+	 */
+	lx_sigaction(LX_SIGCHLD, (void (*)(int))1);
+
 	int flags = CLONE_VFORK | SIGCHLD;
 	return lx_clone((int (*)(void *))entry, stack, flags, arg);
 }

--- a/base-linux/src/platform/lx_hybrid.cc
+++ b/base-linux/src/platform/lx_hybrid.cc
@@ -167,11 +167,6 @@ static void adopt_thread(Thread_meta_data *meta_data)
 	 */
 	lx_sigaction(LX_SIGUSR1, empty_signal_handler);
 
-	/*
-	 * Prevent children from becoming zombies. (SIG_IGN = 1)
-	 */
-	lx_sigaction(LX_SIGCHLD, (void (*)(int))1);
-
 	/* assign 'Thread_meta_data' pointer to TLS entry */
 	pthread_setspecific(tls_key(), meta_data);
 


### PR DESCRIPTION
The call of sigaction within adopt_thread (which was created to fix
issue #271) causes issues in the following call trace:

adopt_thread (meta_data=0x7fc4b0004f20) at .../base-linux/src/platform/lx_hybrid.cc:163
0x000000000049abe3 in Genode::Thread_base::myself () at .../base-linux/src/platform/lx_hybrid.cc:2500x00000000004998b4 in Genode::Ipc_client::Ipc_client (this=0x7fc4b6268e90, srv=..., snd_msg=0x7fc4b6268f00, rcv_msg=<optimized out>) at .../base-linux/src/base/ipc/ipc.cc:138
0x000000000049ba29 in Genode::CapabilityGenode::Signal_session::_callGenode::Signal_session::Rpc_submit (this=<optimized out>, args=..., ret=<optimized out>) at .../base/include/base/rpc_client.h:113
0x000000000049bba5 in callGenode::Signal_session::Rpc_submit (v2=1, v1=..., this=<optimized out>) at .../base/include/base/capability.h:230
Genode::Signal_session_client::submit (this=<optimized out>, receiver=..., cnt=4835049) at .../base/include/signal_session/client.h:39
...

The signal is sent from a native linux process which has its own
signal handling. After this call sigchld for forked processes are
no longer notified in that process.

This commit moves the sigaction call to lx_create_process so that
only processes created within the Genode environment gets the signal
ignored.

This commit also avoided the zombie states in my tests with chroot
loader that what the reason for issue #271.
