### PR TITLE
base: Fix a number of warnings about unused parameters

### DIFF
--- a/base/include/base/allocator_avl.h
+++ b/base/include/base/allocator_avl.h
@@ -241,7 +241,7 @@ namespace Genode {
 			 * The 'sizeof(umword_t)' represents the overhead of the meta-data
 			 * slab allocator.
 			 */
-			size_t overhead(size_t size) { return sizeof(Block) + sizeof(umword_t); }
+			size_t overhead(size_t) { return sizeof(Block) + sizeof(umword_t); }
 
 			bool need_size_for_free() const { return false; }
 	};

--- a/base/include/base/capability.h
+++ b/base/include/base/capability.h
@@ -64,7 +64,7 @@ namespace Genode {
 			                       Meta::Overload_selector<Rpc_arg_inout>) const;
 
 			template <typename T>
-			void _unmarshal_result(Ipc_client &, T &arg,
+			void _unmarshal_result(Ipc_client &, T &,
 			                       Meta::Overload_selector<Rpc_arg_in>) const { }
 
 			/**

--- a/base/include/base/rpc_server.h
+++ b/base/include/base/rpc_server.h
@@ -61,7 +61,7 @@ namespace Genode {
 				_read_args(is, args._2);
 			}
 
-			void _read_args(Ipc_istream &is, Meta::Empty) { }
+			void _read_args(Ipc_istream &, Meta::Empty) { }
 
 			template <typename ARG_LIST>
 			void _write_results(Ipc_ostream &os, ARG_LIST &args)
@@ -72,7 +72,7 @@ namespace Genode {
 				_write_results(os, args._2);
 			}
 
-			void _write_results(Ipc_ostream &os, Meta::Empty) { }
+			void _write_results(Ipc_ostream &, Meta::Empty) { }
 
 			template <typename RPC_FUNCTION, typename EXC_TL>
 			Rpc_exception_code _do_serve(typename RPC_FUNCTION::Server_args &args,

--- a/base/include/base/slab.h
+++ b/base/include/base/slab.h
@@ -248,7 +248,7 @@ namespace Genode {
 			bool   alloc(size_t, void **);
 			void   free(void *addr, size_t) { free(addr); }
 			size_t consumed();
-			size_t overhead(size_t size) { return _block_size/_num_elem; }
+			size_t overhead(size_t) { return _block_size/_num_elem; }
 			bool   need_size_for_free() const { return false; }
 	};
 }

--- a/base/include/cpu_session/cpu_session.h
+++ b/base/include/cpu_session/cpu_session.h
@@ -159,7 +159,7 @@ namespace Genode {
 			 * \param thread  thread to set into single step mode
 			 * \param enable  true = enable single-step mode; false = disable
 			 */
-			virtual void single_step(Thread_capability thread, bool enable) {}
+			virtual void single_step(Thread_capability, bool) {}
 
 			/**
 			 * Return number of CPUs available via the CPU session

--- a/base/include/root/component.h
+++ b/base/include/root/component.h
@@ -39,7 +39,7 @@ namespace Genode {
 
 			Single_client() : _used(0) { }
 
-			void aquire(const char *args)
+			void aquire(const char *)
 			{
 				if (_used)
 					throw Root::Unavailable();
@@ -56,7 +56,7 @@ namespace Genode {
 	 */
 	struct Multiple_clients
 	{
-		void aquire(const char *args) { }
+		void aquire(const char *) { }
 		void release() { }
 	};
 
@@ -146,7 +146,7 @@ namespace Genode {
 			 * \param args     description of additional resources in the
 			 *                 same format as used at session creation
 			 */
-			virtual void _upgrade_session(SESSION_TYPE *session, const char *args) { }
+			virtual void _upgrade_session(SESSION_TYPE *, const char *) { }
 
 			virtual void _destroy_session(SESSION_TYPE *session) {
 				destroy(_md_alloc, session); }

--- a/base/include/util/meta.h
+++ b/base/include/util/meta.h
@@ -460,22 +460,22 @@ namespace Genode {
 		 */
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(RET_TYPE &ret, SERVER &server, ARGS &args,
+		static inline void call_member(RET_TYPE &ret, SERVER &server, ARGS &,
 		                               RET_TYPE (SERVER::*func)())
 		{ ret = (server.*func)(); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(RET_TYPE &ret, SERVER &server, ARGS &args,
+		static inline void call_member(RET_TYPE &ret, SERVER &server, ARGS &,
 		                               RET_TYPE (SERVER::*func)() const)
 		{ ret = (server.*func)(); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &,
 		                               void (SERVER::*func)())
 		{ (server.*func)(); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &,
 		                               void (SERVER::*func)() const)
 		{ (server.*func)(); }
 
@@ -486,7 +486,7 @@ namespace Genode {
 		{ ret = (server.*func)(args.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type))
 		{ (server.*func)(args.get()); }
 
@@ -498,7 +498,7 @@ namespace Genode {
 		{ ret = (server.*func)(args.get(), args._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type))
 		{ (server.*func)(args.get(), args._2.get()); }
@@ -512,7 +512,7 @@ namespace Genode {
 		{ ret = (server.*func)(args.get(), args._2.get(), args._2._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type,
 		                                                    typename Type_at<ARGS, 2>::Type))
@@ -528,7 +528,7 @@ namespace Genode {
 		{ ret = (server.*func)(args.get(), args._2.get(), args._2._2.get(), args._2._2._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type,
 		                                                    typename Type_at<ARGS, 2>::Type,
@@ -546,7 +546,7 @@ namespace Genode {
 		{ ret = (server.*func)(args.get(), args._2.get(), args._2._2.get(), args._2._2._2.get(), args._2._2._2._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type,
 		                                                    typename Type_at<ARGS, 2>::Type,
@@ -567,7 +567,7 @@ namespace Genode {
 		                       args._2._2._2._2.get(), args._2._2._2._2._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type,
 		                                                    typename Type_at<ARGS, 2>::Type,
@@ -591,7 +591,7 @@ namespace Genode {
 		                       args._2._2._2._2.get(), args._2._2._2._2._2.get(), args._2._2._2._2._2._2.get()); }
 
 		template <typename RET_TYPE, typename SERVER, typename ARGS>
-		static inline void call_member(Meta::Empty &ret, SERVER &server, ARGS &args,
+		static inline void call_member(Meta::Empty &, SERVER &server, ARGS &args,
 		                               void (SERVER::*func)(typename Type_at<ARGS, 0>::Type,
 		                                                    typename Type_at<ARGS, 1>::Type,
 		                                                    typename Type_at<ARGS, 2>::Type,

--- a/base/include/x86/cpu/string.h
+++ b/base/include/x86/cpu/string.h
@@ -25,7 +25,7 @@ namespace Genode
 	 *
 	 * \return      Number of bytes not copied
 	 */
-	inline size_t memcpy_cpu(void *dst, const void *src, size_t size) {
+	inline size_t memcpy_cpu(void *, const void *, size_t size) {
 		return size; }
 }
 


### PR DESCRIPTION
The warnings are shown if components using the genode base are
compiled with -Wextra -Wall enabled.
