### PR TITLE
app/chroot: Perform chdir after chroot

### DIFF
--- a/os/src/app/chroot/main.cc
+++ b/os/src/app/chroot/main.cc
@@ -206,6 +206,12 @@ int main(int, char **argv)
 		return 4;
 	}
 
+	if (chdir(cwd_path)) {
+		PERR("chdir to %s failed (errno=%d:%s)", cwd_path,
+		     errno, strerror(errno));
+		return 5;
+	}
+
 	execve("init", argv, environ);
 
 	PERR("execve failed with errno=%d", errno);


### PR DESCRIPTION
This ensures that the process has no access to the outer world.
