### PR TITLE
NOVA: Remove obsolete cap selector lock

### DIFF
--- a/base-nova/include/nova/syscall-generic.h
+++ b/base-nova/include/nova/syscall-generic.h
@@ -529,7 +529,6 @@ namespace Nova {
 		PT_SEL_STARTUP    = 0x1e,
 		PT_SEL_RECALL     = 0x1f,
 		PD_SEL            = 0x1b,
-		PD_SEL_CAP_LOCK   = 0x1c,  /* convention on Genode */
 		SM_SEL_EC_CLIENT  = 0x1c,  /* convention on Genode */
 		SM_SEL_EC         = 0x1d,  /* convention on Genode */
 	};

--- a/base-nova/src/base/env/cap_sel_alloc.cc
+++ b/base-nova/src/base/env/cap_sel_alloc.cc
@@ -24,48 +24,12 @@
 
 using namespace Genode;
 
-
-/**
- * Low-level lock to protect the allocator
- *
- * We cannot use a normal Genode lock because this lock is used by code
- * executed prior the initialization of Genode.
- */
-class Alloc_lock
-{
-	private:
-
-		addr_t _sm_cap;
-
-	public:
-
-		/**
-		 * Constructor
-		 *
-		 * \param sm_cap  capability selector for the used semaphore
-		 */
-		Alloc_lock() : _sm_cap(Nova::PD_SEL_CAP_LOCK) { }
-
-		void lock()
-		{
-			if (Nova::sm_ctrl(_sm_cap, Nova::SEMAPHORE_DOWN))
-				nova_die();
-		}
-
-		void unlock()
-		{
-			if (Nova::sm_ctrl(_sm_cap, Nova::SEMAPHORE_UP))
-				nova_die();
-		}
-};
-
-
 /**
  * Return lock used to protect capability selector allocations
  */
-static Alloc_lock *alloc_lock()
+static Genode::Lock *alloc_lock()
 {
-	static Alloc_lock alloc_lock_inst;
+	static Genode::Lock alloc_lock_inst;
 	return &alloc_lock_inst;
 }
 
@@ -83,7 +47,6 @@ void Cap_selector_allocator::free(addr_t cap, size_t num_caps_log2)
 	alloc_lock()->lock();
 	Bit_allocator::free(cap, num_caps_log2);
 	alloc_lock()->unlock();
-
 }
 
 

--- a/base-nova/src/core/platform.cc
+++ b/base-nova/src/core/platform.cc
@@ -211,7 +211,6 @@ Platform::Platform() :
 	__core_pd_sel = hip->sel_exc;
 
 	/* create lock used by capability allocator */
-	Nova::create_sm(Nova::PD_SEL_CAP_LOCK, __core_pd_sel, 1);
 	Nova::create_sm(Nova::SM_SEL_EC, __core_pd_sel, 0);
 
 	/* locally map the whole I/O port range */

--- a/base-nova/src/core/platform_thread.cc
+++ b/base-nova/src/core/platform_thread.cc
@@ -111,7 +111,6 @@ int Platform_thread::start(void *ip, void *sp)
 	_sel_exc_base = cap_selector_allocator()->alloc(NUM_INITIAL_PT_LOG2);
 
 	addr_t pd_core_sel  = Platform_pd::pd_core_sel();
-	addr_t sm_alloc_sel = _sel_exc_base + PD_SEL_CAP_LOCK;
 	addr_t sm_ec_sel    = _pager->exc_pt_sel() + SM_SEL_EC_CLIENT;
 
 	addr_t remap_src[] = { _pd->parent_pt_sel(),
@@ -162,13 +161,6 @@ int Platform_thread::start(void *ip, void *sp)
 		              Obj_crd(remap_src[i], 0),
 		              Obj_crd(_sel_exc_base + remap_dst[i], 0)))
 			goto cleanup_base;
-	}
-
-	/* Create lock for cap allocator selector */
-	res = create_sm(sm_alloc_sel, pd_core_sel, 1);
-	if (res != NOVA_OK) {
-		PERR("could not create semaphore for capability allocator");
-		goto cleanup_base;
 	}
 
 	pd_sel = cap_selector_allocator()->alloc();


### PR DESCRIPTION
We can use the Genode::Lock abstraction instead of a separate native SM cap.

The code where required some months ago, but became obsolete as now the handling of the main threads in core and in the childs are unified - so each thread has now its own SM cap which is used by the Genode::Lock abstraction.
