### PR TITLE
base-linux: Don't busywait if lx_pollpid returns 0

### DIFF
--- a/base-linux/src/core/platform.cc
+++ b/base-linux/src/core/platform.cc
@@ -102,7 +102,7 @@ void Platform::wait_for_exit()
 		for (;;) {
 			int const pid = lx_pollpid();
 
-			if (pid == -1)
+			if (pid <= 0)
 				break;
 
 			Platform_thread::submit_exception(pid);


### PR DESCRIPTION
This happened when I killed one of the genode clients which was
tracked via an expception_handler. In this case the wait4 syscall
returned 0 and the for(;;) was looped eternally. This caused an
100% CPU utilization for the core binary.
