### PR TITLE
linux: Mark a local fd as closed after mmap

### DIFF
--- a/base-linux/src/base/env/platform_env.cc
+++ b/base-linux/src/base/env/platform_env.cc
@@ -43,6 +43,11 @@ int Platform_env_base::Rm_session_mmap::_dataspace_fd(Dataspace_capability ds)
 }
 
 
+void Platform_env_base::Rm_session_mmap::_dataspace_closed(Dataspace_capability)
+{
+}
+
+
 bool
 Platform_env_base::Rm_session_mmap::_dataspace_writable(Dataspace_capability ds)
 {

--- a/base-linux/src/base/env/platform_env.h
+++ b/base-linux/src/base/env/platform_env.h
@@ -222,6 +222,11 @@ namespace Genode {
 					int _dataspace_fd(Capability<Dataspace>);
 
 					/**
+					 * Mark the dataspace as closed
+					 */
+					void _dataspace_closed(Capability<Dataspace>);
+
+					/**
 					 * Determine whether dataspace is writable
 					 */
 					bool _dataspace_writable(Capability<Dataspace>);

--- a/base-linux/src/base/env/rm_session_mmap.cc
+++ b/base-linux/src/base/env/rm_session_mmap.cc
@@ -56,6 +56,7 @@ Platform_env_base::Rm_session_mmap::_map_local(Dataspace_capability ds,
 	 * process.
 	 */
 	lx_close(fd);
+	_dataspace_closed(ds);
 
 	if (((long)addr_out < 0) && ((long)addr_out > -4095)) {
 		PERR("_map_local: return value of mmap is %ld", (long)addr_out);

--- a/base-linux/src/core/platform.cc
+++ b/base-linux/src/core/platform.cc
@@ -219,6 +219,20 @@ int Platform_env_base::Rm_session_mmap::_dataspace_fd(Capability<Dataspace> ds_c
 	return ds ? ds->fd().dst().socket : -1;
 }
 
+void Platform_env_base::Rm_session_mmap::_dataspace_closed(Dataspace_capability ds_cap)
+{
+	if (core_env()->entrypoint()->is_myself()) {
+		Capability<Linux_dataspace> lx_ds_cap = static_cap_cast<Linux_dataspace>(ds_cap);
+
+		Object_pool<Rpc_object_base>::Guard
+			ds_rpc(core_env()->entrypoint()->lookup_and_lock(lx_ds_cap));
+		Dataspace_component * ds = dynamic_cast<Dataspace_component *>(&*ds_rpc);
+		if (ds) {
+			ds->fd(-1);
+		}
+	}
+}
+
 
 bool Platform_env_base::Rm_session_mmap::_dataspace_writable(Dataspace_capability ds_cap)
 {


### PR DESCRIPTION
Please check if this alternate approach to the problem with lx_sendmsg to a closed FD looks good to you. I already tested in for quite some time in our software.

The method Platform_env_base::Rm_session_mmap::_map_local() calls
lx_close on the file descriptor it maps. This can be fatal, the
file descriptor is still stored within the dataspace and a call to
Ram_session_component::_revoke_ram_ds() will run lx_close on that
file descriptor, even if the file descriptor is used for some other
purposes now.

In our scenario this caused a lx_reply call to fail with:

lx_sendmsg failed with -9 in lx_reply()

because the file descriptor returned by lx_wait was closed before
Ipc_server::_reply() method was called.

To avoid it, I added a _dataspace_closed() method which will mark
the closed file descriptor as closed. There are two cases, the
dataspace is local or remote.

In the remote case nothing happens (because the lx_close call has
no effect out-side of the local process). This is always the case
for a non-core process, this is why the implementation within
base-linux/src/base/env/platform_env.cc is empty.

In the local case the fd(-1) is performed, this is the value the
Ram_session_component::_revoke_ram_ds() method checks for when
deciding if the file descriptor is to be closed.
