### PR TITLE
run/uart fails to run without IO_PORT

### DIFF
--- a/os/run/uart.run
+++ b/os/run/uart.run
@@ -24,6 +24,7 @@ set config  {
 			<service name="RAM"/>
 			<service name="IRQ"/>
 			<service name="IO_MEM"/>
+			<service name="IO_PORT"/>
 			<service name="CAP"/>
 			<service name="PD"/>
 			<service name="RM"/>


### PR DESCRIPTION
Successfully tested with base-foc and base-nova in both 13.11 and master.
