### PR TITLE
GNU Nano noux port, noux_nano.run script included. 

### DIFF
--- a/ports/ports/nano.mk
+++ b/ports/ports/nano.mk
@@ -1,0 +1,28 @@
+NANO      = nano-2.2.6
+NANO_TGZ  = $(NANO).tar.gz
+NANO_URL  = ftp://ftp.gnu.org/pub/gnu/nano
+NANO_SIG  = $(NANO_TGZ).sig
+NANO_KEY  = GNU
+#
+# Interface to top-level prepare Makefile
+#
+PORTS += $(NANO)
+
+#
+
+prepare:: $(CONTRIB_DIR)/$(NANO)
+
+$(DOWNLOAD_DIR)/$(NANO_TGZ):
+		$(VERBOSE)wget -c -P $(DOWNLOAD_DIR) $(NANO_URL)/$(NANO_TGZ) && touch $@
+
+$(DOWNLOAD_DIR)/$(NANO_SIG):
+		$(VERBOSE)wget -c -P $(DOWNLOAD_DIR) $(NANO_URL)/$(NANO_SIG) && touch $@
+
+$(CONTRIB_DIR)/$(NANO): $(DOWNLOAD_DIR)/$(NANO_TGZ).verified
+		$(VERBOSE)tar xzf $(<:.verified=) -C $(CONTRIB_DIR) && touch $@
+
+$(DOWNLOAD_DIR)/$(NANO_TGZ).verified: $(DOWNLOAD_DIR)/$(NANO_TGZ) \
+		$(DOWNLOAD_DIR)/$(NANO_SIG)
+		$(VERBOSE)$(SIGVERIFIER) $(DOWNLOAD_DIR)/$(NANO_TGZ) \
+								 $(DOWNLOAD_DIR)/$(NANO_SIG) $(NANO_KEY)
+		$(VERBOSE)touch $@

--- a/ports/run/noux_nano.run
+++ b/ports/run/noux_nano.run
@@ -1,0 +1,120 @@
+#
+# Uncomment the following line when working on the NANO source code. Otherwise,
+# NANO may get recompiled, yet it does not get reinstalled into 'bin/nano'.
+#
+#exec rm -rf noux-pkg/nano bin/nano
+
+set build_components {
+	core init drivers/timer noux/minimal lib/libc_noux
+	drivers/framebuffer drivers/pci drivers/input
+	server/terminal server/ram_fs
+	test/libports/ncurses
+}
+lappend build_components noux-pkg/nano
+
+build $build_components
+
+exec tar cfv bin/nano.tar -h -C bin/nano .
+
+create_boot_directory
+
+append config {
+	<config verbose="yes">
+		<parent-provides>
+			<service name="ROM"/>
+			<service name="LOG"/>
+			<service name="CAP"/>
+			<service name="RAM"/>
+			<service name="RM"/>
+			<service name="CPU"/>
+			<service name="PD"/>
+			<service name="IRQ"/>
+			<service name="IO_PORT"/>
+			<service name="IO_MEM"/>
+			<service name="SIGNAL"/>
+		</parent-provides>
+		<default-route>
+			<any-service> <any-child/> <parent/> </any-service>
+		</default-route>
+		<start name="timer">
+			<resource name="RAM" quantum="1M"/>
+			<provides><service name="Timer"/></provides>
+		</start> }
+
+append_if [have_spec sdl] config {
+	<start name="fb_sdl">
+		<resource name="RAM" quantum="4M"/>
+		<provides>
+			<service name="Input"/>
+			<service name="Framebuffer"/>
+		</provides>
+	</start>}
+
+append_if [have_spec pci] config {
+	<start name="pci_drv">
+		<resource name="RAM" quantum="1M"/>
+		<provides><service name="PCI"/></provides>
+	</start>}
+
+append_if [have_spec framebuffer] config {
+	<start name="fb_drv">
+		<resource name="RAM" quantum="4M"/>
+		<provides><service name="Framebuffer"/></provides>
+	</start>}
+
+append_if [have_spec ps2] config {
+	<start name="ps2_drv">
+		<resource name="RAM" quantum="1M"/>
+		<provides><service name="Input"/></provides>
+	</start> }
+
+append config {
+		<start name="terminal">
+			<resource name="RAM" quantum="2M"/>
+			<provides><service name="Terminal"/></provides>
+			<config>
+				<keyboard layout="en"/>
+			</config>
+		</start>
+		<start name="noux">
+			<resource name="RAM" quantum="1G"/>
+			<config>
+				<fstab> <tar name="nano.tar" /> </fstab>
+				<start name="/bin/nano">
+					<env name="TERM" value="linux" />
+
+				
+					<!-- Ignore .nanorc configuration -->
+					<arg value="-I" />
+
+				</start>
+			</config>
+		</start>
+	</config>
+}
+
+install_config $config
+
+
+#
+# Boot modules
+#
+
+# generic modules
+set boot_modules {
+	core init timer ld.lib.so noux terminal
+	libc.lib.so libm.lib.so libc_noux.lib.so ncurses.lib.so
+	nano.tar
+}
+
+# platform-specific modules
+lappend_if [have_spec       linux] boot_modules fb_sdl
+lappend_if [have_spec         pci] boot_modules pci_drv
+lappend_if [have_spec framebuffer] boot_modules fb_drv
+lappend_if [have_spec         ps2] boot_modules ps2_drv
+
+build_boot_image $boot_modules
+
+run_genode_until forever
+
+exec rm bin/nano.tar

--- a/ports/src/noux-pkg/nano/target.mk
+++ b/ports/src/noux-pkg/nano/target.mk
@@ -1,0 +1,23 @@
+NOUX_CONFIGURE_ARGS = --disable-glibtest --disable-largefile \
+					  --disable-mouse --disable-extra --disable-nls \
+					  --exec-prefix= --bindir=/bin --sbindir=/bin \
+
+NOUX_CFLAGS += -U__BSD_VISIBLE
+
+LIBS += ncurses
+
+
+#
+# Make the ncurses linking test succeed
+#
+Makefile: dummy_libs
+
+NOUX_LDFLAGS += -L$(PWD)
+
+.SECONDARY: dummy_libs
+dummy_libs: libncurses.a
+
+libncurses.a:
+	$(VERBOSE)$(AR) -rc $@
+
+include $(REP_DIR)/mk/noux.mk


### PR DESCRIPTION
I've ported GNU Nano to noux, and created a noux_nano.run script.  I essentially just copied the noux_vim.run script, and replaced things where applicable.  


I did some very quick testing, to see if anything wasn't working correctly, and saw a few unimplemented calls. I wanted to include them, not sure if they're helpful, but wanted to be complete. 
`
[init -> noux] virtual bool Noux::Terminal_io_channel::ioctl(Noux::Sysio*): OP_TIOCSETAW not implemented
[init -> noux -> /bin/nano] unsupported ioctl (request=0x802c7414)
[init -> terminal] virtual void Char_cell_array_character_screen::rmir(): not implemented
[init -> terminal] virtual void Char_cell_array_character_screen::smam(): not implemented
[init -> terminal] bool Terminal::Decoder::_handle_esc_seq_7(): Sequence '[0;59;10m' is not implemented`