### PR TITLE
Genode::Connection: Disallow copy and assignment

### DIFF
--- a/base/include/base/connection.h
+++ b/base/include/base/connection.h
@@ -23,7 +23,7 @@ namespace Genode {
 	 * Representation of an open connection to a service
 	 */
 	template <typename SESSION_TYPE>
-	class Connection
+	class Connection : public Noncopyable
 	{
 		public:
 


### PR DESCRIPTION
When an object derived from Genode::Connection is copied we had
strange issues. An example is that the first RPC invocation works
correctly but the second one blocks or even delivers incorrect data.

We can avoid this issue if the object is always passed by reference.
Ensure this pattern by providing an noncopyable property which
results in compile failure in other classes (due to private) and
in the same class (due to missing implementation).
