### PR TITLE
Fix use-after-free bug in init

### DIFF
--- a/os/include/init/child.h
+++ b/os/include/init/child.h
@@ -557,7 +557,12 @@ namespace Init {
 				} catch (Xml_node::Nonexistent_sub_node) { }
 			}
 
-			virtual ~Child() { }
+			virtual ~Child() {
+				Genode::Service *s;
+				while ((s = _child_services->find_by_server(&_server))) {
+					_child_services->remove(s);
+				}
+			}
 
 			/**
 			 * Return true if the child has the specified name


### PR DESCRIPTION
Fix a use-after-free bug concerning the use case where the config
of the init process changes dynamically. The childs' services were not
removed from the corresponding Service_registry properly.
