### PR TITLE
base: fix bug in String::valid()

### DIFF
--- a/base/include/util/string.h
+++ b/base/include/util/string.h
@@ -479,7 +479,7 @@ namespace Genode {
 			static constexpr size_t capacity() { return CAPACITY; }
 
 			bool valid() const {
-				return (_length <= CAPACITY) && (_buf[_length - 1] == '\0'); }
+				return (_length <= CAPACITY) && (_length != 0) && (_buf[_length - 1] == '\0'); }
 
 			char const *string() const { return valid() ? _buf : ""; }
 


### PR DESCRIPTION
String::valid() does not check whether _length is zero.
Consequently, this leads to _buf[-1] being evaluated.
