### PR TITLE
bugfix: motion events with absolute coordinates are now merged correctly, fixes #1207

### DIFF
--- a/repos/dde_linux/src/lib/usb/input/evdev.c
+++ b/repos/dde_linux/src/lib/usb/input/evdev.c
@@ -45,7 +45,7 @@ void genode_evdev_event(struct input_handle *handle, unsigned int type,
 	/* generate arguments and call back */
 	enum input_event_type arg_type;
 	unsigned arg_keycode = KEY_UNKNOWN;
-	int arg_ax = 0, arg_ay = 0, arg_rx = 0, arg_ry = 0;
+	int arg_ax = -1, arg_ay = -1, arg_rx = 0, arg_ry = 0;
 
 	switch (type) {
 

--- a/repos/os/include/input/event.h
+++ b/repos/os/include/input/event.h
@@ -50,7 +50,7 @@ namespace Input {
 			 * Constructors
 			 */
 			Event():
-				_type(INVALID), _code(0), _ax(0), _ay(0), _rx(0), _ry(0) { }
+				_type(INVALID), _code(0), _ax(-1), _ay(-1), _rx(0), _ry(0) { }
 
 			Event(Type type, int code, int ax, int ay, int rx, int ry):
 				_type(type), _code(code),

--- a/repos/os/src/server/nitpicker/input.h
+++ b/repos/os/src/server/nitpicker/input.h
@@ -56,7 +56,7 @@ static Input::Event merge_motion_events(Input::Event const *ev, unsigned n)
 {
 	Input::Event res;
 	for (unsigned i = 0; i < n; i++, ev++)
-		res = Input::Event(Input::Event::MOTION, 0, ev->ax(), ev->ay(),
+		res = Input::Event(Input::Event::MOTION, 0, ev->ax() == -1 ? res.ax() : ev->ax(), ev->ay() == -1 ? res.ay() : ev-> ay(),
 		                   res.rx() + ev->rx(), res.ry() + ev->ry());
 	return res;
 }

--- a/repos/os/src/server/nitpicker/user_state.cc
+++ b/repos/os/src/server/nitpicker/user_state.cc
@@ -56,12 +56,14 @@ void User_state::handle_event(Input::Event ev, Canvas_base &canvas)
 
 	/* transparently handle absolute and relative motion events */
 	if (type == Event::MOTION) {
-		if ((ev.rx() || ev.ry()) && ev.ax() == 0 && ev.ay() == 0) {
+		if ((ev.rx() || ev.ry()) && ev.ax() == -1 && ev.ay() == -1) {
 			ax = Genode::max(0, Genode::min((int)size().w(), ax + ev.rx()));
 			ay = Genode::max(0, Genode::min((int)size().h(), ay + ev.ry()));
 		} else {
-			ax = ev.ax();
-			ay = ev.ay();
+			if( ev.ax() != -1)
+				ax = ev.ax();
+			if( ev.ay() != -1)
+				ay = ev.ay();
 		}
 	}
 


### PR DESCRIPTION
An absolute motion event updates only one of two axis. It is not suitable to simply take the newest absolute event as this only updates on axis and sets the other axis to zero. With this patch absolute coordinates are initialized with the invalid value -1. Only valid coordinates are used to overwrite old coordinates on merge. The mouse cursor in nitpicker is only updated for valid coordinates.
