### PR TITLE
init: fix priority partitioning

### DIFF
--- a/repos/os/include/init/child_policy.h
+++ b/repos/os/include/init/child_policy.h
@@ -105,7 +105,7 @@ namespace Init {
 				if (Genode::strcmp(service, "CPU") || _prio_levels_log2 == 0)
 					return;
 
-				long priority = Arg_string::find_arg(args, "priority").long_value(0);
+				long priority = Arg_string::find_arg(args, "priority").long_value(0) & (Cpu_session::PRIORITY_LIMIT-1);
 
 				long discarded_prio_lsb_bits_mask = (1 << _prio_levels_log2) - 1;
 				if (priority & discarded_prio_lsb_bits_mask) {


### PR DESCRIPTION
Without masking the bits above Cpu_session::PRIORITY_LIMIT, a child
could open a CPU session with a priority outside its assigned range.
