### PR TITLE
dde_linux: fix bug in find_next_zero_bit_le

### DIFF
--- a/repos/dde_linux/src/lib/usb/lx_emul.cc
+++ b/repos/dde_linux/src/lib/usb/lx_emul.cc
@@ -838,7 +838,7 @@ long find_next_zero_bit_le(const void *addr,
 	}
 
 	for (; offset < max_size; offset++)
-		if (!(*(unsigned long*)addr & (1 << offset)))
+		if (!(*(unsigned long*)addr & (1L << offset)))
 			return offset;
 
 	PERR("No zero bit findable");


### PR DESCRIPTION
value '1' has a default type of int, but long is needed to cover all 64 bits
