### PR TITLE
signal: fix infinite loop

### DIFF
--- a/repos/base/src/base/signal/signal.cc
+++ b/repos/base/src/base/signal/signal.cc
@@ -280,9 +280,8 @@ Signal_context_capability Signal_receiver::manage(Signal_context *context)
 	/* register context at process-wide registry */
 	signal_context_registry()->insert(&context->_registry_le);
 
-	bool try_again;
+	bool try_again = false;
 	do {
-		try_again = false;
 		try {
 
 			/* use signal context as imprint */


### PR DESCRIPTION
There is an infinite loop in signal.cc. The comment mentions that the loop shall be exited after a second try, which is controlled by setting the try_again variable to true after the first try. However, the variable is reset to false on each iteration.