### PR TITLE
hw_x86_64 changes

### DIFF
--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -63,6 +63,14 @@ class Genode::Ioapic : public Mmio
 		};
 
 		/**
+		 * Return whether 'irq' is an edge-triggered interrupt
+		 */
+		bool _edge_triggered(unsigned const irq)
+		{
+			return irq <= Board::ISA_IRQ_END || irq > IRTE_COUNT;
+		}
+
+		/**
 		 * Create redirection table entry for given IRQ
 		 */
 		Irte::access_t _create_irt_entry(unsigned const irq)
@@ -71,19 +79,11 @@ class Genode::Ioapic : public Mmio
 			Irte::Mask::set(irte, 1);
 
 			/* Use level-triggered, low-active mode for non-legacy IRQs */
-			if (irq > Board::ISA_IRQ_END) {
+			if (!_edge_triggered(irq)) {
 				Irte::Pol::set(irte, 1);
 				Irte::Trg::set(irte, 1);
 			}
 			return irte;
-		}
-
-		/**
-		 * Return whether 'irq' is an edge-triggered interrupt
-		 */
-		bool _edge_triggered(unsigned const irq)
-		{
-			return irq <= Board::ISA_IRQ_END || irq >  IRTE_COUNT;
 		}
 
 	public:

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -68,6 +68,7 @@ class Genode::Ioapic : public Mmio
 		Irte::access_t _create_irt_entry(unsigned const irq)
 		{
 			Irte::access_t irte = REMAP_BASE + irq;
+			Irte::Mask::set(irte, 1);
 
 			/* Use level-triggered, low-active mode for non-legacy IRQs */
 			if (irq > Board::ISA_IRQ_END) {

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -67,7 +67,10 @@ class Genode::Ioapic : public Mmio
 		 */
 		bool _edge_triggered(unsigned const irq)
 		{
-			return irq <= Board::ISA_IRQ_END || irq > IRTE_COUNT;
+			if ((irq >= 0 && irq <= 8) || (irq >= 12 && irq <= Board::ISA_IRQ_END))
+				return true;
+
+			return false;
 		}
 
 		/**

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -83,8 +83,7 @@ class Genode::Ioapic : public Mmio
 		 */
 		bool _edge_triggered(unsigned const irq)
 		{
-			return irq <= REMAP_BASE + Board::ISA_IRQ_END ||
-			       irq >  REMAP_BASE + IRTE_COUNT;
+			return irq <= Board::ISA_IRQ_END || irq >  IRTE_COUNT;
 		}
 
 	public:
@@ -104,6 +103,8 @@ class Genode::Ioapic : public Mmio
 		/* Set/unset mask bit of IRTE for given vector */
 		void toggle_mask(unsigned const vector, bool const set)
 		{
+			const unsigned irq = vector - REMAP_BASE;
+
 			/*
 			 * Only mask existing RTEs and do *not* mask edge-triggered
 			 * interrupts to avoid losing them while masked, see Intel
@@ -112,9 +113,9 @@ class Genode::Ioapic : public Mmio
 			 * flag and edge-triggered interrupts or:
 			 * http://yarchive.net/comp/linux/edge_triggered_interrupts.html
 			 */
-			if (_edge_triggered(vector) && set) { return; }
+			if (_edge_triggered(irq) && set) { return; }
 
-			write<Ioregsel>(IOREDTBL + (2 * (vector - REMAP_BASE)));
+			write<Ioregsel>(IOREDTBL + (2 * irq));
 			Irte::access_t irte = read<Iowin>();
 			Irte::Mask::set(irte, set);
 			write<Iowin>(irte);

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -112,7 +112,7 @@ class Genode::Ioapic : public Mmio
 			 * flag and edge-triggered interrupts or:
 			 * http://yarchive.net/comp/linux/edge_triggered_interrupts.html
 			 */
-			if (_edge_triggered(vector)) { return; }
+			if (_edge_triggered(vector) && set) { return; }
 
 			write<Ioregsel>(IOREDTBL + (2 * (vector - REMAP_BASE)));
 			Irte::access_t irte = read<Iowin>();

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -71,7 +71,6 @@ class Genode::Ioapic : public Mmio
 
 			/* Use level-triggered, high-active mode for non-legacy IRQs */
 			if (irq > Board::ISA_IRQ_END) {
-				Irte::access_t irte = 0;
 				Irte::Pol::set(irte, 1);
 				Irte::Trg::set(irte, 1);
 			}

--- a/repos/base-hw/src/core/include/spec/x86/pic.h
+++ b/repos/base-hw/src/core/include/spec/x86/pic.h
@@ -69,7 +69,7 @@ class Genode::Ioapic : public Mmio
 		{
 			Irte::access_t irte = REMAP_BASE + irq;
 
-			/* Use level-triggered, high-active mode for non-legacy IRQs */
+			/* Use level-triggered, low-active mode for non-legacy IRQs */
 			if (irq > Board::ISA_IRQ_END) {
 				Irte::Pol::set(irte, 1);
 				Irte::Trg::set(irte, 1);

--- a/tool/run/power_on/qemu
+++ b/tool/run/power_on/qemu
@@ -51,6 +51,10 @@ proc run_power_on { } {
 	}
 	if {[have_spec platform_vpb926]} { append qemu_args " -M versatilepb     -m 128 " }
 	if {[have_spec platform_vea9x4]} { append qemu_args " -M vexpress-a9 -cpu cortex-a9 -m 256 " }
+	if {[have_spec hw_x86_64]} {
+		regsub -all {\-m ([0-9])+} $qemu_args "" qemu_args
+		append qemu_args " -m 512 "
+	}
 
 	# on x86, we support booting via pxe or iso/disk image
 	if {[have_spec x86]} {


### PR DESCRIPTION
This set of changes contains some fixes and one extension for hw_x86_64:

- The initial page tables have been extracted so they can be changed easily for platforms based on x86_64.
- Several log messages have been extended to provide the same amount of debug information as on ARM platforms.
- FPU initialization and lazy-state handling has been fixed to work properly on hardware.
- Write entire 64 bits of the I/O APIC interrupt redirection table entries when initializing the x86 PIC.
- Populate the I/O memory allocator with the entire address space excluding the core only RAM regions, aligning the MMIO allocator initialization with how it is done for other x86 kernels.

The last item removes the limitation discussed in the last comment of #1448.
