### PR TITLE
base-hw: add Zynq-7000 support

### DIFF
--- a/repos/base-hw/lib/mk/platform_parallella/core.mk
+++ b/repos/base-hw/lib/mk/platform_parallella/core.mk
@@ -1,0 +1,16 @@
+#
+# \brief  Build config for Genodes core process
+# \author Johannes Schlatow
+# \date   2014-12-15
+#
+
+# add include paths
+INC_DIR += $(REP_DIR)/src/core/include/spec/parallella
+INC_DIR += $(REP_DIR)/src/core/include/spec/xilinx
+
+# add C++ sources
+SRC_CC += platform_services.cc
+SRC_CC += spec/zynq/platform_support.cc
+
+# include less specific configuration
+include $(REP_DIR)/lib/mk/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/platform_parallella/test-hw_info.mk
+++ b/repos/base-hw/lib/mk/platform_parallella/test-hw_info.mk
@@ -1,0 +1,11 @@
+#
+# \brief  Build config for a core that prints hardware information
+# \author Martin Stein
+# \date   2011-12-16
+#
+
+# add C++ sources
+SRC_CC += spec/arm_v7/info.cc
+
+# decrlare source directories
+vpath % $(REP_DIR)/src/test/hw_info

--- a/repos/base-hw/lib/mk/platform_zedboard/core.mk
+++ b/repos/base-hw/lib/mk/platform_zedboard/core.mk
@@ -1,0 +1,17 @@
+#
+# \brief  Build config for Genodes core process
+# \author Mark Albers
+# \author Johannes Schlatow
+# \date   2015-03-12
+#
+
+# add include paths
+INC_DIR += $(REP_DIR)/src/core/include/spec/zedboard
+INC_DIR += $(REP_DIR)/src/core/include/spec/xilinx
+
+# add C++ sources
+SRC_CC += platform_services.cc
+SRC_CC += spec/zynq/platform_support.cc
+
+# include less specific configuration
+include $(REP_DIR)/lib/mk/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/platform_zedboard/test-hw_info.mk
+++ b/repos/base-hw/lib/mk/platform_zedboard/test-hw_info.mk
@@ -1,0 +1,11 @@
+#
+# \brief  Build config for a core that prints hardware information
+# \author Martin Stein
+# \date   2011-12-16
+#
+
+# add C++ sources
+SRC_CC += spec/arm_v7/info.cc
+
+# decrlare source directories
+vpath % $(REP_DIR)/src/test/hw_info

--- a/repos/base-hw/lib/mk/platform_zynq/core.mk
+++ b/repos/base-hw/lib/mk/platform_zynq/core.mk
@@ -1,0 +1,16 @@
+#
+# \brief  Build config for Genodes core process
+# \author Johannes Schlatow
+# \date   2014-12-15
+#
+
+# add include paths
+INC_DIR += $(REP_DIR)/src/core/include/spec/zynq
+INC_DIR += $(REP_DIR)/src/core/include/spec/xilinx
+
+# add C++ sources
+SRC_CC += platform_services.cc
+SRC_CC += spec/zynq/platform_support.cc
+
+# include less specific configuration
+include $(REP_DIR)/lib/mk/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/platform_zynq/test-hw_info.mk
+++ b/repos/base-hw/lib/mk/platform_zynq/test-hw_info.mk
@@ -1,0 +1,11 @@
+#
+# \brief  Build config for a core that prints hardware information
+# \author Martin Stein
+# \date   2011-12-16
+#
+
+# add C++ sources
+SRC_CC += spec/arm_v7/info.cc
+
+# decrlare source directories
+vpath % $(REP_DIR)/src/test/hw_info

--- a/repos/base-hw/mk/spec-hw_parallella.mk
+++ b/repos/base-hw/mk/spec-hw_parallella.mk
@@ -1,0 +1,18 @@
+#
+# \brief  Offer build configurations that are specific to base-hw and Zynq/parallella
+# \author Johannes Schlatow
+# \date   2014-12-15
+#
+
+# denote which specs are also fulfilled by this spec
+SPECS += hw platform_parallella
+
+# configure multiprocessor mode
+NR_OF_CPUS = 1
+
+# set address where to link the text segment at
+LD_TEXT_ADDR ?= 0x00100000
+
+# include implied specs
+include $(call select_from_repositories,mk/spec-hw.mk)
+include $(call select_from_repositories,mk/spec-platform_parallella.mk)

--- a/repos/base-hw/mk/spec-hw_zedboard.mk
+++ b/repos/base-hw/mk/spec-hw_zedboard.mk
@@ -1,0 +1,19 @@
+#
+# \brief  Offer build configurations that are specific to base-hw and Zynq/Zedboard
+# \author Mark Albers
+# \author Johannes Schlatow
+# \date   2015-03-12
+#
+
+# denote which specs are also fulfilled by this spec
+SPECS += hw platform_zedboard
+
+# configure multiprocessor mode
+NR_OF_CPUS = 1
+
+# set address where to link the text segment at
+LD_TEXT_ADDR ?= 0x00100000
+
+# include implied specs
+include $(call select_from_repositories,mk/spec-hw.mk)
+include $(call select_from_repositories,mk/spec-platform_zedboard.mk)

--- a/repos/base-hw/mk/spec-hw_zynq.mk
+++ b/repos/base-hw/mk/spec-hw_zynq.mk
@@ -1,0 +1,18 @@
+#
+# \brief  Offer build configurations that are specific to base-hw and Zynq
+# \author Johannes Schlatow
+# \date   2014-12-15
+#
+
+# denote which specs are also fulfilled by this spec
+SPECS += hw platform_zynq
+
+# configure multiprocessor mode
+NR_OF_CPUS = 1
+
+# set address where to link the text segment at
+LD_TEXT_ADDR ?= 0x00100000
+
+# include implied specs
+include $(call select_from_repositories,mk/spec-hw.mk)
+include $(call select_from_repositories,mk/spec-platform_zynq.mk)

--- a/repos/base-hw/run/nested_init.run
+++ b/repos/base-hw/run/nested_init.run
@@ -72,7 +72,7 @@ build_boot_image "core init"
 append qemu_args " -m 64 -nographic"
 
 # execute the test in qemu if the targeted platform is supported
-if {[have_spec hw_vea9x4] || [have_spec hw_pbxa9]} {
+if {[have_spec hw_vea9x4] || [have_spec hw_pbxa9] || [have_spec hw_zynq]} {
 	run_genode_until "No children to start.*\n" 10
 	puts "Test succeeded"
 }

--- a/repos/base-hw/src/core/include/spec/parallella/board.h
+++ b/repos/base-hw/src/core/include/spec/parallella/board.h
@@ -1,0 +1,126 @@
+/*
+ * \brief  Board driver for core on Zynq/Parallella
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ * \author Stefan Kalkowski
+ * \date   2014-06-02
+ */
+
+/*
+ * Copyright (C) 2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+/* core includes */
+#include <util/mmio.h>
+#include <spec/cortex_a9/board_support.h>
+
+namespace Genode
+{
+	struct Board : Cortex_a9::Board
+	{
+		enum {
+			UART_MMIO_BASE = UART_1_MMIO_BASE
+		};
+
+		/**
+		 * L2 outer cache controller
+		 */
+		struct Pl310 : Mmio {
+
+			enum Trustzone_hypervisor_syscalls {
+				L2_CACHE_SET_DEBUG_REG = 0x100,
+				L2_CACHE_ENABLE_REG    = 0x102,
+				L2_CACHE_AUX_REG       = 0x109,
+			};
+
+			static inline void
+			trustzone_hypervisor_call(addr_t func, addr_t val)
+			{
+				/* FIXME trustzone support */
+//				register addr_t _func asm("r12") = func;
+//				register addr_t _val  asm("r0")  = val;
+//				asm volatile("dsb; smc #0" :: "r" (_func), "r" (_val)
+//				             : "memory", "cc", "r1", "r2", "r3", "r4", "r5",
+//				               "r6", "r7", "r8", "r9", "r10", "r11");
+			}
+
+			struct Control   : Register <0x100, 32>
+			{
+				struct Enable : Bitfield<0,1> {};
+			};
+
+			struct Aux : Register<0x104, 32>
+			{
+				struct Associativity  : Bitfield<16,1> { };
+				struct Way_size       : Bitfield<17,3> { };
+				struct Share_override : Bitfield<22,1> { };
+				struct Reserved       : Bitfield<25,1> { };
+				struct Ns_lockdown    : Bitfield<26,1> { };
+				struct Ns_irq_ctrl    : Bitfield<27,1> { };
+				struct Data_prefetch  : Bitfield<28,1> { };
+				struct Inst_prefetch  : Bitfield<29,1> { };
+				struct Early_bresp    : Bitfield<30,1> { };
+
+				static access_t init_value()
+				{
+					access_t v = 0;
+					Associativity::set(v, 1);
+					Way_size::set(v, 3);
+					Share_override::set(v, 1);
+					Reserved::set(v, 1);
+					Ns_lockdown::set(v, 1);
+					Ns_irq_ctrl::set(v, 1);
+					Data_prefetch::set(v, 1);
+					Inst_prefetch::set(v, 1);
+					Early_bresp::set(v, 1);
+					return v;
+				}
+			};
+
+			struct Irq_mask                : Register <0x214, 32> {};
+			struct Irq_clear               : Register <0x220, 32> {};
+			struct Cache_sync              : Register <0x730, 32> {};
+			struct Invalidate_by_way       : Register <0x77c, 32> {};
+			struct Clean_invalidate_by_way : Register <0x7fc, 32> {};
+
+			inline void sync() { while (read<Cache_sync>()) ; }
+
+			void invalidate()
+			{
+				write<Invalidate_by_way>((1 << 16) - 1);
+				sync();
+			}
+
+			void flush()
+			{
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x3);
+				write<Clean_invalidate_by_way>((1 << 16) - 1);
+				sync();
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x0);
+			}
+
+			Pl310(addr_t const base) : Mmio(base)
+			{
+				trustzone_hypervisor_call(L2_CACHE_AUX_REG,
+				                          Pl310::Aux::init_value());
+				trustzone_hypervisor_call(L2_CACHE_ENABLE_REG, 1);
+				write<Irq_mask>(0);
+				write<Irq_clear>(0xffffffff);
+			}
+		};
+
+		static void outer_cache_invalidate();
+		static void outer_cache_flush();
+		static void prepare_kernel();
+		static void secondary_cpus_ip(void * const ip) { }
+		static bool is_smp() { return true; }
+	};
+}
+
+#endif /* _BOARD_H_ */

--- a/repos/base-hw/src/core/include/spec/xilinx/serial.h
+++ b/repos/base-hw/src/core/include/spec/xilinx/serial.h
@@ -1,0 +1,45 @@
+/*
+ * \brief  Serial output driver for core
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ */
+
+/*
+ * Copyright (C) 2012-2013 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _SERIAL_H_
+#define _SERIAL_H_
+
+/* core includes */
+#include <board.h>
+
+/* Genode includes */
+#include <drivers/uart/xilinx_uartps_base.h>
+
+namespace Genode
+{
+	/**
+	 * Serial output driver for core
+	 */
+	class Serial : public Xilinx_uartps_base
+	{
+		public:
+
+			/**
+			 * Constructor
+			 *
+			 * \param baud_rate  targeted transfer baud-rate
+			 */
+			Serial(unsigned const baud_rate)
+			:
+				Xilinx_uartps_base(Board::UART_MMIO_BASE,
+				              Board::UART_CLOCK, baud_rate)
+			{ }
+	};
+}
+
+#endif /* _SERIAL_H_ */

--- a/repos/base-hw/src/core/include/spec/zedboard/board.h
+++ b/repos/base-hw/src/core/include/spec/zedboard/board.h
@@ -1,0 +1,133 @@
+/*
+ * \brief  Board driver for core on Zynq/Zedboard
+ * \author Mark Albers
+ * \date   2015-03-12
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ * \author Stefan Kalkowski
+ * \date   2014-06-02
+ */
+
+/*
+ * Copyright (C) 2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+/* core includes */
+#include <util/mmio.h>
+#include <spec/cortex_a9/board_support.h>
+
+namespace Genode
+{
+	struct Board : Cortex_a9::Board
+	{
+		enum {
+			UART_MMIO_BASE = UART_1_MMIO_BASE,
+			RAM_0_SIZE = 0x20000000, /* 512MB */
+			DDR_CLOCK  = 533333313,
+			FCLK_CLK0  = 100*1000*1000, /* AXI */
+			FCLK_CLK1  = 20250*1000, /* Cam */
+			FCLK_CLK2  = 150*1000*1000, /* AXI HP */
+		};
+
+		/**
+		 * L2 outer cache controller
+		 */
+		struct Pl310 : Mmio {
+
+			enum Trustzone_hypervisor_syscalls {
+				L2_CACHE_SET_DEBUG_REG = 0x100,
+				L2_CACHE_ENABLE_REG    = 0x102,
+				L2_CACHE_AUX_REG       = 0x109,
+			};
+
+			static inline void
+			trustzone_hypervisor_call(addr_t func, addr_t val)
+			{
+				/* FIXME trustzone support */
+//				register addr_t _func asm("r12") = func;
+//				register addr_t _val  asm("r0")  = val;
+//				asm volatile("dsb; smc #0" :: "r" (_func), "r" (_val)
+//				             : "memory", "cc", "r1", "r2", "r3", "r4", "r5",
+//				               "r6", "r7", "r8", "r9", "r10", "r11");
+			}
+
+			struct Control   : Register <0x100, 32>
+			{
+				struct Enable : Bitfield<0,1> {};
+			};
+
+			struct Aux : Register<0x104, 32>
+			{
+				struct Associativity  : Bitfield<16,1> { };
+				struct Way_size       : Bitfield<17,3> { };
+				struct Share_override : Bitfield<22,1> { };
+				struct Reserved       : Bitfield<25,1> { };
+				struct Ns_lockdown    : Bitfield<26,1> { };
+				struct Ns_irq_ctrl    : Bitfield<27,1> { };
+				struct Data_prefetch  : Bitfield<28,1> { };
+				struct Inst_prefetch  : Bitfield<29,1> { };
+				struct Early_bresp    : Bitfield<30,1> { };
+
+				static access_t init_value()
+				{
+					access_t v = 0;
+					Associativity::set(v, 1);
+					Way_size::set(v, 3);
+					Share_override::set(v, 1);
+					Reserved::set(v, 1);
+					Ns_lockdown::set(v, 1);
+					Ns_irq_ctrl::set(v, 1);
+					Data_prefetch::set(v, 1);
+					Inst_prefetch::set(v, 1);
+					Early_bresp::set(v, 1);
+					return v;
+				}
+			};
+
+			struct Irq_mask                : Register <0x214, 32> {};
+			struct Irq_clear               : Register <0x220, 32> {};
+			struct Cache_sync              : Register <0x730, 32> {};
+			struct Invalidate_by_way       : Register <0x77c, 32> {};
+			struct Clean_invalidate_by_way : Register <0x7fc, 32> {};
+
+			inline void sync() { while (read<Cache_sync>()) ; }
+
+			void invalidate()
+			{
+				write<Invalidate_by_way>((1 << 16) - 1);
+				sync();
+			}
+
+			void flush()
+			{
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x3);
+				write<Clean_invalidate_by_way>((1 << 16) - 1);
+				sync();
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x0);
+			}
+
+			Pl310(addr_t const base) : Mmio(base)
+			{
+				trustzone_hypervisor_call(L2_CACHE_AUX_REG,
+				                          Pl310::Aux::init_value());
+				trustzone_hypervisor_call(L2_CACHE_ENABLE_REG, 1);
+				write<Irq_mask>(0);
+				write<Irq_clear>(0xffffffff);
+			}
+		};
+
+		static void outer_cache_invalidate();
+		static void outer_cache_flush();
+		static void prepare_kernel();
+		static void secondary_cpus_ip(void * const ip) { }
+		static bool is_smp() { return true; }
+	};
+}
+
+#endif /* _BOARD_H_ */

--- a/repos/base-hw/src/core/include/spec/zynq/board.h
+++ b/repos/base-hw/src/core/include/spec/zynq/board.h
@@ -1,0 +1,125 @@
+/*
+ * \brief  Board driver for core on Zynq
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ * \author Stefan Kalkowski
+ * \date   2014-06-02
+ */
+
+/*
+ * Copyright (C) 2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+/* core includes */
+#include <util/mmio.h>
+#include <spec/cortex_a9/board_support.h>
+
+namespace Genode
+{
+	struct Board : Cortex_a9::Board
+	{
+		enum {
+			UART_MMIO_BASE = UART_0_MMIO_BASE
+		};
+		/**
+		 * L2 outer cache controller
+		 */
+		struct Pl310 : Mmio {
+
+			enum Trustzone_hypervisor_syscalls {
+				L2_CACHE_SET_DEBUG_REG = 0x100,
+				L2_CACHE_ENABLE_REG    = 0x102,
+				L2_CACHE_AUX_REG       = 0x109,
+			};
+
+			static inline void
+			trustzone_hypervisor_call(addr_t func, addr_t val)
+			{
+				/* FIXME trustzone support */
+//				register addr_t _func asm("r12") = func;
+//				register addr_t _val  asm("r0")  = val;
+//				asm volatile("dsb; smc #0" :: "r" (_func), "r" (_val)
+//				             : "memory", "cc", "r1", "r2", "r3", "r4", "r5",
+//				               "r6", "r7", "r8", "r9", "r10", "r11");
+			}
+
+			struct Control   : Register <0x100, 32>
+			{
+				struct Enable : Bitfield<0,1> {};
+			};
+
+			struct Aux : Register<0x104, 32>
+			{
+				struct Associativity  : Bitfield<16,1> { };
+				struct Way_size       : Bitfield<17,3> { };
+				struct Share_override : Bitfield<22,1> { };
+				struct Reserved       : Bitfield<25,1> { };
+				struct Ns_lockdown    : Bitfield<26,1> { };
+				struct Ns_irq_ctrl    : Bitfield<27,1> { };
+				struct Data_prefetch  : Bitfield<28,1> { };
+				struct Inst_prefetch  : Bitfield<29,1> { };
+				struct Early_bresp    : Bitfield<30,1> { };
+
+				static access_t init_value()
+				{
+					access_t v = 0;
+					Associativity::set(v, 1);
+					Way_size::set(v, 3);
+					Share_override::set(v, 1);
+					Reserved::set(v, 1);
+					Ns_lockdown::set(v, 1);
+					Ns_irq_ctrl::set(v, 1);
+					Data_prefetch::set(v, 1);
+					Inst_prefetch::set(v, 1);
+					Early_bresp::set(v, 1);
+					return v;
+				}
+			};
+
+			struct Irq_mask                : Register <0x214, 32> {};
+			struct Irq_clear               : Register <0x220, 32> {};
+			struct Cache_sync              : Register <0x730, 32> {};
+			struct Invalidate_by_way       : Register <0x77c, 32> {};
+			struct Clean_invalidate_by_way : Register <0x7fc, 32> {};
+
+			inline void sync() { while (read<Cache_sync>()) ; }
+
+			void invalidate()
+			{
+				write<Invalidate_by_way>((1 << 16) - 1);
+				sync();
+			}
+
+			void flush()
+			{
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x3);
+				write<Clean_invalidate_by_way>((1 << 16) - 1);
+				sync();
+				trustzone_hypervisor_call(L2_CACHE_SET_DEBUG_REG, 0x0);
+			}
+
+			Pl310(addr_t const base) : Mmio(base)
+			{
+				trustzone_hypervisor_call(L2_CACHE_AUX_REG,
+				                          Pl310::Aux::init_value());
+				trustzone_hypervisor_call(L2_CACHE_ENABLE_REG, 1);
+				write<Irq_mask>(0);
+				write<Irq_clear>(0xffffffff);
+			}
+		};
+
+		static void outer_cache_invalidate();
+		static void outer_cache_flush();
+		static void prepare_kernel();
+		static void secondary_cpus_ip(void * const ip) { }
+		static bool is_smp() { return true; }
+	};
+}
+
+#endif /* _BOARD_H_ */

--- a/repos/base-hw/src/core/spec/zynq/platform_support.cc
+++ b/repos/base-hw/src/core/spec/zynq/platform_support.cc
@@ -1,0 +1,74 @@
+/*
+ * \brief   Platform implementations specific for base-hw and Zynq
+ * \author  Johannes Schlatow
+ * \date    2014-12-15
+ */
+
+/*
+ * Copyright (C) 2012-2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+/* core includes */
+#include <platform.h>
+#include <board.h>
+#include <cpu.h>
+#include <pic.h>
+#include <unmanaged_singleton.h>
+
+using namespace Genode;
+
+Native_region * Platform::_ram_regions(unsigned const i)
+{
+	static Native_region _regions[] =
+	{
+		{ Board::RAM_0_BASE, Board::RAM_0_SIZE }
+	};
+	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
+}
+
+
+Native_region * mmio_regions(unsigned const i)
+{
+	static Native_region _regions[] =
+	{
+		{ Board::MMIO_0_BASE, Board::MMIO_0_SIZE },
+		{ Board::MMIO_1_BASE, Board::MMIO_1_SIZE },
+		{ Board::QSPI_MMIO_BASE, Board::QSPI_MMIO_SIZE },
+		{ Board::OCM_MMIO_BASE,  Board::OCM_MMIO_SIZE },
+		{ Board::AXI_0_MMIO_BASE, Board::AXI_0_MMIO_SIZE },
+		{ Board::AXI_1_MMIO_BASE, Board::AXI_1_MMIO_SIZE }
+	};
+	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
+}
+
+
+Native_region * Platform::_core_only_mmio_regions(unsigned const i)
+{
+	static Native_region _regions[] =
+	{
+		/* core timer and PIC */
+		{ Board::CORTEX_A9_PRIVATE_MEM_BASE,
+		  Board::CORTEX_A9_PRIVATE_MEM_SIZE },
+		/* both UARTs */
+		{ Board::UART_0_MMIO_BASE, Board::UART_SIZE },
+		{ Board::UART_1_MMIO_BASE, Board::UART_SIZE },
+		/* L2 cache controller */
+		{ Board::PL310_MMIO_BASE, Board::PL310_MMIO_SIZE }
+	};
+	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
+}
+
+
+Cpu::User_context::User_context() { cpsr = Psr::init_user(); }
+
+
+static Board::Pl310 * l2_cache() {
+	return unmanaged_singleton<Board::Pl310>(Board::PL310_MMIO_BASE); }
+
+
+void Board::outer_cache_invalidate() { l2_cache()->invalidate(); }
+void Board::outer_cache_flush()      { l2_cache()->flush();      }
+void Board::prepare_kernel()         { l2_cache()->invalidate(); }

--- a/repos/base/include/drivers/uart/xilinx_uartps_base.h
+++ b/repos/base/include/drivers/uart/xilinx_uartps_base.h
@@ -1,0 +1,176 @@
+/*
+ * \brief  Base UART driver for the Xilinx UART PS used on Zynq devices
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ */
+
+/*
+ * Copyright (C) 2011-2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__UART__XILINX_UARTPS_BASE_H_
+#define _INCLUDE__DRIVERS__UART__XILINX_UARTPS_BASE_H_
+
+/* Genode includes */
+#include <util/mmio.h>
+
+namespace Genode
+{
+	/**
+	 * Base driver Xilinx UART PS module
+	 */
+	class Xilinx_uartps_base : public Mmio
+	{
+		protected:
+			/**
+			* Control register
+			*/
+			struct Uart_cr : Register<0x00, 32>
+			{
+				struct Rx_reset  : Bitfield<0, 1> { };
+				struct Tx_reset  : Bitfield<1, 1> { };
+				struct Rx_enable : Bitfield<2, 1> { };
+				struct Rx_disable: Bitfield<3, 1> { };
+				struct Tx_enable : Bitfield<4, 1> { };
+				struct Tx_disable: Bitfield<5, 1> { };
+				struct Res_to    : Bitfield<6, 1> { };
+				struct Start_tbrk: Bitfield<7, 1> { };
+				struct Stop_tbrk : Bitfield<8, 1> { };
+			};
+
+			/**
+			* Mode register
+			*/
+			struct Uart_mr : Register<0x04, 32>
+			{
+				struct Clock_sel  : Bitfield<0, 1> { };
+				struct Char_len   : Bitfield<1, 2> {
+					enum {
+						_8_BIT = 0,
+						_7_BIT = 2,
+						_6_BIT = 3
+					};
+				};
+				struct Parity     : Bitfield<3, 3> {
+					enum {
+						_EVEN      = 0,
+						_ODD       = 1,
+						_FORCED_0  = 2,
+						_FORCED_1  = 3,
+						_NO_PARITY = 4
+					};
+				};
+				struct Nbr_stop   : Bitfield<6, 2> {
+					enum {
+						_ONE          = 0,
+						_ONE_AND_HALF = 1,
+						_TWO          = 2
+					};
+				};
+				struct Chan_mode  : Bitfield<8, 2> {
+					enum {
+						_NORMAL          = 0,
+						_AUTO_ECHO       = 1,
+						_LOCAL_LOOPBACK  = 2,
+						_REMOTE_LOOPBACK = 3
+					};
+				};
+			};
+
+			/**
+			* Baudgen register
+			*/
+			struct Uart_baudgen : Register<0x18, 32>
+			{
+				struct Clock_div  : Bitfield<0, 16> { };
+			};
+
+			/**
+			* Status register
+			*/
+			struct Uart_sr       : Register<0x2C, 32>
+			{
+				struct Rx_trig    : Bitfield<0, 1> { };
+				struct Rx_empty   : Bitfield<1, 1> { };
+				struct Rx_full    : Bitfield<2, 1> { };
+				struct Tx_empty   : Bitfield<3, 1> { };
+				struct Tx_full    : Bitfield<4, 1> { };
+				struct Rx_active  : Bitfield<10,1> { };
+				struct Tx_active  : Bitfield<11,1> { };
+				struct Flow_delay : Bitfield<12,1> { };
+				struct Ttrig      : Bitfield<13,1> { };
+				struct Tnful      : Bitfield<14,1> { };
+			};
+
+			/**
+			* FIFO register
+			*/
+			struct Uart_fifo : Register<0x30, 32>
+			{
+				struct Data   : Bitfield<0, 8> { };
+			};
+
+			/**
+			* Bauddiv register
+			*/
+			struct Uart_bauddiv : Register<0x34, 32>
+			{
+				struct Bdiv : Bitfield<0,8> { };
+			};
+
+			void _init(unsigned long const clock, unsigned long const baud_rate)
+			{
+				/* reset UART */
+				write<Uart_cr>(Uart_cr::Tx_reset::bits(1)
+				             | Uart_cr::Rx_reset::bits(1));
+
+				/* set baud rate */
+				unsigned div = 4;
+				write<Uart_bauddiv::Bdiv>(div);
+				write<Uart_baudgen::Clock_div>(clock / baud_rate / (div + 1));
+
+				/* set 8N1 */
+				write<Uart_mr>(Uart_mr::Parity::bits(Uart_mr::Parity::_NO_PARITY)
+				             | Uart_mr::Char_len::bits(Uart_mr::Char_len::_8_BIT)
+								 | Uart_mr::Nbr_stop::bits(Uart_mr::Nbr_stop::_ONE));
+
+				/* enable */
+				write<Uart_cr>(Uart_cr::Rx_enable::bits(1)
+				             | Uart_cr::Tx_enable::bits(1));
+
+			}
+
+		public:
+			/**
+			 * Constructor
+			 *
+			 * \param  base       MMIO base address
+			 * \param  clock      reference clock
+			 * \param  baud_rate  targeted baud rate
+			 */
+			Xilinx_uartps_base(addr_t const base, unsigned long const clock,
+			              unsigned long const baud_rate) : Mmio(base)
+			{
+				/* reset and init UART */
+				_init(clock, baud_rate);
+			}
+
+			/**
+			 * Transmit ASCII char 'c'
+			 */
+			void put_char(char const c)
+			{
+				/* wait as long as the transmission buffer is full */
+				while (read<Uart_sr::Tx_full>()) ;
+
+				/* transmit character */
+				write<Uart_fifo::Data>(c);
+			}
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__UART__XILINX_UARTPS_BASE_H_ */
+

--- a/repos/base/include/platform/zynq/drivers/board_base.h
+++ b/repos/base/include/platform/zynq/drivers/board_base.h
@@ -1,0 +1,123 @@
+/*
+ * \brief  Base driver for the Zynq (QEMU)
+ * \author Mark Albers
+ * \author Timo Wischer
+ * \author Johannes Schlatow
+ * \date   2014-12-15
+ */
+
+/*
+ * Copyright (C) 2011-2014 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__BOARD_BASE_H_
+#define _INCLUDE__DRIVERS__BOARD_BASE_H_
+
+namespace Genode
+{
+	/**
+	 * Base driver for the Zynq platform
+	 */
+	struct Board_base
+	{
+		enum
+		{
+			/* device IO memory */
+			MMIO_0_BASE    = 0xe0000000, /* IOP devices */
+			MMIO_0_SIZE    = 0x10000000,
+			MMIO_1_BASE    = 0xF8000000, /* Programmable register via APB */
+			MMIO_1_SIZE    = 0x02000000,
+			QSPI_MMIO_BASE = 0xFC000000, /* Quad-SPI */
+			QSPI_MMIO_SIZE = 0x01000000,
+			OCM_MMIO_BASE  = 0xFFFC0000, /* OCM upper address range */
+			OCM_MMIO_SIZE  = 0x00040000,
+			I2C0_MMIO_BASE = 0xE0004000,
+			I2C1_MMIO_BASE = 0xE0005000,
+			I2C_MMIO_SIZE = 0x1000,
+
+			/* normal RAM */
+			RAM_0_BASE = 0x00000000,
+			RAM_0_SIZE = 0x40000000, /* 1GiB */
+
+			/* AXI */
+			AXI_0_MMIO_BASE = 0x40000000, /* PL AXI Slave port #0 */
+			AXI_0_MMIO_SIZE = 0x40000000,
+			AXI_1_MMIO_BASE = 0x80000000, /* PL AXI Slave port #1 */
+			AXI_1_MMIO_SIZE = 0x40000000,
+
+			/* clocks (assuming 6:2:1 mode) */
+			PS_CLOCK = 33333333,
+			ARM_PLL_CLOCK = 1333333*1000,
+			DDR_PLL_CLOCK = 1066667*1000,
+			IO_PLL_CLOCK  = 1000*1000*1000,
+			CPU_1x_CLOCK = 111111115,
+			CPU_6x4x_CLOCK = 6*CPU_1x_CLOCK,
+			CPU_3x2x_CLOCK = 3*CPU_1x_CLOCK,
+			CPU_2x_CLOCK   = 2*CPU_1x_CLOCK,
+
+			/* UART controllers */
+			UART_0_MMIO_BASE = MMIO_0_BASE + 0x0000,
+			UART_1_MMIO_BASE = MMIO_0_BASE + 0x1000,
+			UART_SIZE = 0x1000,
+			UART_CLOCK = 50*1000*1000,
+			UART_0_IRQ = 59,
+			UART_1_IRQ = 82,
+
+			/* DDR */
+			DDR_CLOCK  = 400*1000*1000,
+			QSPI_CLOCK = 200*1000*1000,
+			ETH_CLOCK  = 125*1000*1000,
+			SD_CLOCK   =  50*1000*1000,
+
+			FCLK_CLK0  = 100*1000*1000, /* AXI */
+			FCLK_CLK1  = 200*1000*1000, /* AXI VDMA */
+                    	FCLK_CLK2  = 200*1000*1000, /* HDMI */
+                       	FCLK_CLK3  =  40*1000*1000, /* Epiphany */
+
+			/* CPU */
+			CORTEX_A9_PRIVATE_MEM_BASE = 0xf8f00000,
+			CORTEX_A9_PRIVATE_MEM_SIZE = 0x00002000,
+			CORTEX_A9_CLOCK = CPU_6x4x_CLOCK,
+			CORTEX_A9_PRIVATE_TIMER_CLK = CORTEX_A9_CLOCK, /* FIXME not exactly sure about this */
+
+			/* CPU cache */
+			PL310_MMIO_BASE = MMIO_1_BASE + 0xF02000,
+			PL310_MMIO_SIZE = 0x1000,
+			CACHE_LINE_SIZE_LOG2 = 2, /* FIXME get correct value from board spec */
+
+			/* TTC (triple timer counter) */
+			TTC0_MMIO_BASE = MMIO_1_BASE + 0x1000,
+			TTC0_MMIO_SIZE = 0xfff,
+			TTC1_MMIO_BASE = MMIO_1_BASE + 0x2000,
+			TTC1_MMIO_SIZE = 0xfff,
+			TTC0_IRQ_0     = 42,
+			TTC0_IRQ_1     = 43,
+			TTC0_IRQ_2     = 44,
+			TTC1_IRQ_0     = 69,
+			TTC1_IRQ_1     = 70,
+			TTC1_IRQ_2     = 71,
+
+			/* Ethernet MAC PS */
+			EMAC_0_MMIO_BASE	= 0xE000B000,
+			EMAC_0_MMIO_SIZE	= 0x1000,
+			EMAC_0_IRQ			= 54,
+			EMAC_0_IRQ_WAKE_UP	= 55,
+
+			/* GPIO */
+			GPIO_MMIO_SIZE = 0x1000,
+
+			/* VDMA */
+			VDMA_MMIO_SIZE = 0x10000,
+
+			/* wether board provides security extension */
+			SECURITY_EXTENSION = 0,
+
+		};
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__BOARD_BASE_H_ */
+

--- a/repos/base/mk/spec-platform_parallella.mk
+++ b/repos/base/mk/spec-platform_parallella.mk
@@ -1,0 +1,18 @@
+#
+# Enable peripherals of the platform
+#
+SPECS += cortex_a9 platform_parallella cadence_gem
+# SPEC += gpio framebuffer usb
+
+#
+# Pull in CPU specifics
+#
+SPECS += arm_v7a
+
+#
+# Add device parameters to include search path
+#
+REP_INC_DIR += include/platform/zynq
+
+include $(call select_from_repositories,mk/spec-cortex_a9.mk)
+include $(call select_from_repositories,mk/spec-arm_v7a.mk)

--- a/repos/base/mk/spec-platform_zedboard.mk
+++ b/repos/base/mk/spec-platform_zedboard.mk
@@ -1,0 +1,18 @@
+#
+# Enable peripherals of the platform
+#
+SPECS += cortex_a9 platform_zedboard
+# SPEC += gpio framebuffer usb
+
+#
+# Pull in CPU specifics
+#
+SPECS += arm_v7a
+
+#
+# Add device parameters to include search path
+#
+REP_INC_DIR += include/platform/zynq
+
+include $(call select_from_repositories,mk/spec-cortex_a9.mk)
+include $(call select_from_repositories,mk/spec-arm_v7a.mk)

--- a/repos/base/mk/spec-platform_zynq.mk
+++ b/repos/base/mk/spec-platform_zynq.mk
@@ -1,0 +1,18 @@
+#
+# Enable peripherals of the platform
+#
+SPECS += cortex_a9 platform_zynq cadence_gem
+# SPEC += gpio framebuffer usb
+
+#
+# Pull in CPU specifics
+#
+SPECS += arm_v7a
+
+#
+# Add device parameters to include search path
+#
+REP_INC_DIR += include/platform/zynq
+
+include $(call select_from_repositories,mk/spec-cortex_a9.mk)
+include $(call select_from_repositories,mk/spec-arm_v7a.mk)

--- a/repos/os/include/drivers/timer/ttc_base.h
+++ b/repos/os/include/drivers/timer/ttc_base.h
@@ -1,0 +1,231 @@
+/*
+ * \brief  Basic driver for the Zynq Triple Counter Timer
+ * \author Johannes Schlatow
+ * \date   2015-03-05
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__TIMER__TTC_BASE_H_
+#define _INCLUDE__DRIVERS__TIMER__TTC_BASE_H_
+
+/* Genode includes */
+#include <util/mmio.h>
+
+namespace Genode
+{
+	/**
+	 * Basic driver for the Zynq TTC
+	 *
+	 * The TTC has three timers. The index of the timer to be used must be provides
+	 * as a template argument (0-2).
+	 *
+	 * (see Xilinx ug585)
+	 */
+	template <unsigned IDX, unsigned long CLK>
+	class Ttc_base : public Mmio
+	{
+		enum {
+			TICS_PER_MS = CLK / 1000,
+			TICS_PER_US = TICS_PER_MS / 1000,
+		};
+
+		public:
+
+			/**
+			 * Constructor, clears interrupt output
+			 */
+			Ttc_base(addr_t const mmio_base) : Mmio(mmio_base + IDX*0x04)
+			{
+				clear_interrupt();
+				write<typename Control::Disable>(1);
+				/* enable all interrupts */
+				write<Irqen>(0xff);
+				/* set match registers to 0 */
+				write<Match1>(0);
+				write<Match2>(0);
+				write<Match3>(0);
+				/* set maximum interval so that max_value() does not return 0 */
+				write<Interval>(Value::max_value());
+			}
+
+			/* Clock control register */
+			struct Clock : Register<0x00, 8>
+			{
+				struct Prescale_en  : Bitfield<0, 1> { };
+				struct Prescale     : Bitfield<1, 4> { };
+				struct Clk_src      : Bitfield<5, 1>
+				{
+					enum {
+						PCLK = 0,
+						EXT = 1
+					};
+				};
+				struct Ext_edge     : Bitfield<6, 1> { };
+			};
+
+			/* Counter control register */
+			struct Control : Register<0x0C, 8>
+			{
+				struct Disable    : Bitfield<0,1> { };
+				struct Mode       : Bitfield<1,1> {
+					enum {
+						OVERFLOW = 0,
+						INTERVAL = 1
+					};
+				};
+				struct Decrement  : Bitfield<2, 1> { };
+				struct Match      : Bitfield<3, 1> { };
+				struct Reset      : Bitfield<4, 1> { };
+				struct Wave_en    : Bitfield<5, 1> { };
+				struct Wave_pol   : Bitfield<6, 1> { };
+			};
+
+			/* Counter value */
+			struct Value : Register<0x18, 16>
+			{
+				static access_t max_value() { return ~0; }
+			};
+
+			struct Interval : Register<0x24, 16> { };
+
+			struct Match1 : Register<0x30, 16> { };
+
+			struct Match2 : Register<0x3C, 16> { };
+
+			struct Match3 : Register<0x48, 16> { };
+
+			struct Irq : Register<0x54, 8>
+			{
+				struct Interval : Bitfield<0, 1> { };
+				struct Match1   : Bitfield<1, 1> { };
+				struct Match2   : Bitfield<2, 1> { };
+				struct Match3   : Bitfield<3, 1> { };
+				struct Overflow : Bitfield<4, 1> { };
+				struct EventTmr : Bitfield<5, 1> { };
+			};
+
+			struct Irqen : Register<0x60, 8>
+			{
+				struct Interval : Bitfield<0, 1> { };
+				struct Match1   : Bitfield<1, 1> { };
+				struct Match2   : Bitfield<2, 1> { };
+				struct Match3   : Bitfield<3, 1> { };
+				struct Overflow : Bitfield<4, 1> { };
+				struct EventTmr : Bitfield<5, 1> { };
+			};
+
+			struct EventTmrCtrl : Register<0x6C, 8>
+			{
+				struct Enable   : Bitfield<0, 1> { };
+				struct Low      : Bitfield<1, 1> { };
+				struct Overflow : Bitfield<2, 1> {
+					enum {
+						ONE_SHOT = 0,
+						CONTINUE = 1
+					};
+				};
+			};
+
+			struct EventTmr : Register<0x78, 16> { };
+
+			/**
+			 * Run the timer in order that it raises IRQ when
+			 * it reaches zero, then stop
+			 *
+			 * FIXME not sure how this can be implemented
+			 *
+			 * \param  tics  native timer value used to assess the delay
+			 *               of the timer interrupt as of this call
+			 */
+			void run_and_stop(unsigned long const tics)
+			{
+				/* configure timer for a one-shot */
+				clear_interrupt();
+				write<Control>(Control::Disable::bits(1) |
+				            Control::Mode::bits(Control::Mode::INTERVAL) |
+				            Control::Decrement::bits(1) |
+				            Control::Match::bits(0) | 
+				            Control::Reset::bits(0) | 
+								Control::Wave_en::bits(1));
+
+				/* load and enable timer */
+				write<Interval>(tics);
+				write<typename Control::Disable>(0);
+			}
+
+			/**
+			 * Run the timer in order that it raises IRQ when it reaches the target value,
+			 * then continue
+			 *
+			 * \param  tics  native timer value used to assess the delay
+			 *               of the timer interrupt as of this call
+			 */
+			void run_and_wrap(unsigned long const tics)
+			{
+				/* configure the timer in order that it reloads on timeout */
+				clear_interrupt();
+				write<Control>(Control::Disable::bits(1) |
+				            Control::Mode::bits(Control::Mode::INTERVAL) |
+				            Control::Decrement::bits(1) |
+				            Control::Match::bits(0) |
+				            Control::Reset::bits(0) |
+								Control::Wave_en::bits(1));
+
+				/* Set initial timer value and enable timer */
+				write<Interval>(tics);
+				write<typename Control::Disable>(0);
+			}
+
+			/**
+			 * Current timer value
+			 */
+			unsigned long value() const { return read<Value>(); }
+
+			/**
+			 * Get timer value and corresponding wrapped status of timer
+			 */
+			unsigned long value(bool & wrapped) const
+			{
+				unsigned long v = read<Value>();
+				wrapped = (bool)read<Irq>();
+				return wrapped ? read<Value>() : v;
+			}
+
+			/**
+			 * Clear interrupt output line
+			 */
+			void clear_interrupt() { read<Irq>(); }
+
+			/**
+			 * Translate milliseconds to a native timer value
+			 */
+			static unsigned long ms_to_tics(unsigned long const ms) {
+				return ms * TICS_PER_MS; }
+
+			/**
+			 * Translate native timer value to microseconds
+			 */
+			static unsigned long tics_to_us(unsigned long const tics) {
+				return tics / TICS_PER_US; }
+
+			/**
+			 * Translate microseconds to a native timer value
+			 */
+			static unsigned long us_to_tics(unsigned long const us) {
+				return us * TICS_PER_US; }
+
+			/**
+			 * Translate native timer value to microseconds
+			 */
+			unsigned long max_value() const { return read<Interval>(); }
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__TIMER__A9_PRIVATE_TIMER_H_ */
+

--- a/repos/os/include/gpio_session/zynq/capability.h
+++ b/repos/os/include/gpio_session/zynq/capability.h
@@ -1,0 +1,22 @@
+/*
+ * \brief  Zynq Gpio session capability type
+ * \author Mark Albers
+ * \date   2015-04-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__GPIO_SESSION__CAPABILITY_H_
+#define _INCLUDE__GPIO_SESSION__CAPABILITY_H_
+
+#include <base/capability.h>
+#include <gpio_session/zynq/gpio_session.h>
+
+namespace Gpio { typedef Genode::Capability<Session> Session_capability; }
+
+#endif /* _INCLUDE__GPIO_SESSION__CAPABILITY_H_ */

--- a/repos/os/include/gpio_session/zynq/client.h
+++ b/repos/os/include/gpio_session/zynq/client.h
@@ -1,0 +1,32 @@
+/*
+ * \brief  Client-side Zynq Gpio session interface
+ * \author Mark Albers
+ * \date   2015-04-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__GPIO_SESSION_H__CLIENT_H_
+#define _INCLUDE__GPIO_SESSION_H__CLIENT_H_
+
+#include <gpio_session/zynq/capability.h>
+#include <base/rpc_client.h>
+
+namespace Gpio {
+
+	struct Session_client : Genode::Rpc_client<Session>
+	{
+		explicit Session_client(Session_capability session)
+		: Genode::Rpc_client<Session>(session) { }
+
+        bool write(Genode::uint32_t data, bool isChannel2 = false) { return call<Rpc_write>(data, isChannel2); }
+        Genode::uint32_t read(bool isChannel2 = false) { return call<Rpc_read>(isChannel2); }
+	};
+}
+
+#endif /* _INCLUDE__GPIO_SESSION_H__CLIENT_H_ */

--- a/repos/os/include/gpio_session/zynq/connection.h
+++ b/repos/os/include/gpio_session/zynq/connection.h
@@ -1,0 +1,30 @@
+/*
+ * \brief  Connection to Zynq Gpio session
+ * \author Mark Albers
+ * \date   2015-04-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__GPIO_SESSION__CONNECTION_H_
+#define _INCLUDE__GPIO_SESSION__CONNECTION_H_
+
+#include <gpio_session/zynq/client.h>
+#include <base/connection.h>
+
+namespace Gpio {
+
+	struct Connection : Genode::Connection<Session>, Session_client
+	{
+        Connection(unsigned gpio_number)
+        : Genode::Connection<Session>(session("ram_quota=8K, gpio=%zd", gpio_number)),
+		  Session_client(cap()) { }
+	};
+}
+
+#endif /* _INCLUDE__GPIO_SESSION__CONNECTION_H_ */

--- a/repos/os/include/gpio_session/zynq/gpio_session.h
+++ b/repos/os/include/gpio_session/zynq/gpio_session.h
@@ -1,0 +1,54 @@
+/*
+ * \brief  Zynq Gpio session interface
+ * \author Mark Albers
+ * \date   2015-04-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__GPIO_SESSION__GPIO_SESSION_H_
+#define _INCLUDE__GPIO_SESSION__GPIO_SESSION_H_
+
+#include <base/signal.h>
+#include <session/session.h>
+
+namespace Gpio {
+
+	struct Session : Genode::Session
+	{
+		static const char *service_name() { return "Gpio"; }
+
+		virtual ~Session() { }
+
+		/**
+         * Write
+		 *
+         * \param data
+		 */
+        virtual bool write(Genode::uint32_t data, bool isChannel2) = 0;
+
+		/**
+         * Read
+		 *
+         * \return data
+		 */
+        virtual Genode::uint32_t read(bool isChannel2) = 0;
+
+
+		/*******************
+		 ** RPC interface **
+		 *******************/
+
+        GENODE_RPC(Rpc_write, bool, write, Genode::uint32_t, bool);
+        GENODE_RPC(Rpc_read, Genode::uint32_t, read, bool);
+
+        GENODE_RPC_INTERFACE(Rpc_write, Rpc_read);
+	};
+}
+
+#endif /* _INCLUDE__GPIO_SESSION__GPIO_SESSION_H_ */

--- a/repos/os/include/i2c_session/zynq/capability.h
+++ b/repos/os/include/i2c_session/zynq/capability.h
@@ -1,0 +1,25 @@
+/*
+ * \brief  I2C bus driver session capability type
+ * \author Mark Albers
+ * \date   2015-04-13
+ * \author Alexander Tarasikov <alexander.tarasikov@gmail.com>
+ * \date   2012-09-18
+ */
+
+/*
+ * Copyright (C) 2012 Ksys Labs LLC
+ * Copyright (C) 2012-2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__I2C_SESSION__CAPABILITY_H_
+#define _INCLUDE__I2C_SESSION__CAPABILITY_H_
+
+#include <base/capability.h>
+#include <i2c_session/zynq/i2c_session.h>
+
+namespace I2C { typedef Genode::Capability<Session> Session_capability; }
+
+#endif /* _INCLUDE__I2C_SESSION__CAPABILITY_H_ */

--- a/repos/os/include/i2c_session/zynq/client.h
+++ b/repos/os/include/i2c_session/zynq/client.h
@@ -1,0 +1,43 @@
+/*
+ * \brief  Client-side i2c interface
+ * \author Mark Albers
+ * \date   2015-04-13
+ * \author Alexander Tarasikov <alexander.tarasikov@gmail.com>
+ * \date   2012-09-18
+ */
+
+/*
+ * Copyright (C) 2012 Ksys Labs LLC
+ * Copyright (C) 2012-2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__I2C_SESSION__CLIENT_H_
+#define _INCLUDE__I2C_SESSION__CLIENT_H_
+
+#include <i2c_session/zynq/capability.h>
+#include <base/rpc_client.h>
+
+namespace I2C {
+
+	struct Session_client : Genode::Rpc_client<Session>
+	{
+		explicit Session_client(Session_capability session)
+		: Genode::Rpc_client<Session>(session) { }
+
+		bool read_byte_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg, Genode::uint8_t *data)
+		{
+			return call<Rpc_read_byte_16bit_reg>(adr, reg, data);
+		}
+
+		bool write_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg,
+			Genode::uint8_t data)
+		{
+			return call<Rpc_write_16bit_reg>(adr, reg, data);
+		}
+	};
+}
+
+#endif /* _INCLUDE__I2C_SESSION__CLIENT_H_ */

--- a/repos/os/include/i2c_session/zynq/connection.h
+++ b/repos/os/include/i2c_session/zynq/connection.h
@@ -1,0 +1,34 @@
+/*
+ * \brief  Connection to i2c service
+ * \author Mark Albers
+ * \author Alexander Tarasikov <alexander.tarasikov@gmail.com>
+ * \date   2012-09-18
+ */
+
+/*
+ * Copyright (C) 2012 Ksys Labs LLC
+ * Copyright (C) 2012 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__I2C_SESSION__CONNECTION_H_
+#define _INCLUDE__I2C_SESSION__CONNECTION_H_
+
+#include <i2c_session/zynq/client.h>
+#include <base/connection.h>
+
+namespace I2C {
+
+	class Connection : public Genode::Connection<Session>,
+	                   public Session_client
+	{
+	public:
+		Connection(unsigned int bus_num) :
+			Genode::Connection<Session>(session("ram_quota=4K, bus=%zd", bus_num)),
+			Session_client(cap()) { }
+	};
+}
+
+#endif /* _INCLUDE__I2C_SESSION__CONNECTION_H_ */

--- a/repos/os/include/i2c_session/zynq/i2c_session.h
+++ b/repos/os/include/i2c_session/zynq/i2c_session.h
@@ -1,0 +1,69 @@
+/*
+ * \brief  I2C session interface
+ * \author Mark Albers
+ * \date   2015-04-13
+ * \author Alexander Tarasikov <alexander.tarasikov@gmail.com>
+ * \date   2012-09-18
+ */
+
+/*
+ * Copyright (C) 2012 Ksys Labs LLC
+ * Copyright (C) 2012-2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__I2C_SESSION__I2C_SESSION_H_
+#define _INCLUDE__I2C_SESSION__I2C_SESSION_H_
+
+#include <base/signal.h>
+#include <session/session.h>
+
+namespace I2C {
+
+	struct Session : Genode::Session
+	{
+		static const char *service_name() { return "I2C"; }
+
+		virtual ~Session() { }
+
+		/**
+		 * Read a single byte from a 16 bit register of the device
+		 *
+		 * \param adr the address of the device on the bus
+		 * \param reg the register to read
+		 * \param data the read value
+		 *
+		 */
+		virtual bool read_byte_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg, Genode::uint8_t *data) = 0;
+		
+		/**
+		 * Write a single data byte to a 16 bit register
+		 *
+		 * \param adr the address of the device on the bus
+		 * \param reg the register to write
+		 * \param data the value to write
+		 *
+		 */
+		virtual bool write_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg,
+			Genode::uint8_t data) = 0;
+
+
+		/*********************
+		 ** RPC declaration **
+		 *********************/
+
+		GENODE_RPC(Rpc_read_byte_16bit_reg, bool, read_byte_16bit_reg,
+			Genode::uint8_t, Genode::uint16_t, Genode::uint8_t*);
+		GENODE_RPC(Rpc_write_16bit_reg, bool, write_16bit_reg,
+			Genode::uint8_t, Genode::uint16_t, Genode::uint8_t);
+
+		GENODE_RPC_INTERFACE(
+			Rpc_read_byte_16bit_reg,
+			Rpc_write_16bit_reg
+		);
+	};
+}
+
+#endif /* _INCLUDE__I2C_SESSION__I2C_SESSION_H_ */

--- a/repos/os/include/vdma_session/zynq/capability.h
+++ b/repos/os/include/vdma_session/zynq/capability.h
@@ -1,0 +1,22 @@
+/*
+ * \brief  Zynq VDMA session capability type
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__VDMA_SESSION__CAPABILITY_H_
+#define _INCLUDE__VDMA_SESSION__CAPABILITY_H_
+
+#include <base/capability.h>
+#include <vdma_session/zynq/vdma_session.h>
+
+namespace Vdma { typedef Genode::Capability<Session> Session_capability; }
+
+#endif /* _INCLUDE__VDMA_SESSION__CAPABILITY_H_ */

--- a/repos/os/include/vdma_session/zynq/client.h
+++ b/repos/os/include/vdma_session/zynq/client.h
@@ -1,0 +1,42 @@
+/*
+ * \brief  Client-side Zynq VDMA session interface
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__VDMA_SESSION_H__CLIENT_H_
+#define _INCLUDE__VDMA_SESSION_H__CLIENT_H_
+
+#include <vdma_session/zynq/capability.h>
+#include <base/rpc_client.h>
+
+#define S2MM false
+#define MM2S true
+
+namespace Vdma {
+
+	struct Session_client : Genode::Rpc_client<Session>
+	{
+		explicit Session_client(Session_capability session)
+		: Genode::Rpc_client<Session>(session) { }
+
+        bool setConfig(Genode::uint32_t data, bool isMM2S) { return call<Rpc_setConfig>(data, isMM2S); }
+
+        bool setStride(Genode::uint16_t data, bool isMM2S) { return call<Rpc_setStride>(data, isMM2S); }
+
+        bool setWidth(Genode::uint16_t data, bool isMM2S) { return call<Rpc_setWidth>(data, isMM2S); }
+
+        bool setHeight(Genode::uint16_t data, bool isMM2S) { return call<Rpc_setHeight>(data, isMM2S); }
+
+        bool setAddr(Genode::uint32_t data, bool isMM2S) { return call<Rpc_setAddr>(data, isMM2S); }
+	};
+}
+
+#endif /* _INCLUDE__VDMA_SESSION_H__CLIENT_H_ */

--- a/repos/os/include/vdma_session/zynq/connection.h
+++ b/repos/os/include/vdma_session/zynq/connection.h
@@ -1,0 +1,30 @@
+/*
+ * \brief  Connection to Zynq VDMA session
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__VDMA_SESSION__CONNECTION_H_
+#define _INCLUDE__VDMA_SESSION__CONNECTION_H_
+
+#include <vdma_session/zynq/client.h>
+#include <base/connection.h>
+
+namespace Vdma {
+
+	struct Connection : Genode::Connection<Session>, Session_client
+	{
+        Connection(unsigned vdma_number)
+        : Genode::Connection<Session>(session("ram_quota=8K, vdma=%zd", vdma_number)),
+		  Session_client(cap()) { }
+	};
+}
+
+#endif /* _INCLUDE__VDMA_SESSION__CONNECTION_H_ */

--- a/repos/os/include/vdma_session/zynq/vdma_session.h
+++ b/repos/os/include/vdma_session/zynq/vdma_session.h
@@ -1,0 +1,54 @@
+/*
+ * \brief  Zynq VDMA session interface
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__VDMA_SESSION__VDMA_SESSION_H_
+#define _INCLUDE__VDMA_SESSION__VDMA_SESSION_H_
+
+#include <base/signal.h>
+#include <session/session.h>
+
+namespace Vdma {
+
+	struct Session : Genode::Session
+	{
+        static const char *service_name() { return "Vdma"; }
+
+		virtual ~Session() { }
+
+        virtual bool setConfig(Genode::uint32_t data, bool isMM2S) = 0;
+
+        virtual bool setStride(Genode::uint16_t data, bool isMM2S) = 0;
+
+        virtual bool setWidth(Genode::uint16_t data, bool isMM2S) = 0;
+
+        virtual bool setHeight(Genode::uint16_t data, bool isMM2S) = 0;
+
+        virtual bool setAddr(Genode::uint32_t data, bool isMM2S) = 0;
+
+
+		/*******************
+		 ** RPC interface **
+		 *******************/
+
+        GENODE_RPC(Rpc_setConfig, bool, setConfig, Genode::uint32_t, bool);
+        GENODE_RPC(Rpc_setStride, bool, setStride, Genode::uint16_t, bool);
+        GENODE_RPC(Rpc_setWidth, bool, setWidth, Genode::uint16_t, bool);
+        GENODE_RPC(Rpc_setHeight, bool, setHeight, Genode::uint16_t, bool);
+        GENODE_RPC(Rpc_setAddr, bool, setAddr, Genode::uint32_t, bool);
+
+        GENODE_RPC_INTERFACE(Rpc_setConfig, Rpc_setStride, Rpc_setWidth,
+                             Rpc_setHeight, Rpc_setAddr);
+    };
+}
+
+#endif /* _INCLUDE__VDMA_SESSION__VDMA_SESSION_H_ */

--- a/repos/os/lib/mk/hw_parallella/timer.mk
+++ b/repos/os/lib/mk/hw_parallella/timer.mk
@@ -1,0 +1,3 @@
+INC_DIR += $(REP_DIR)/src/drivers/timer/hw $(REP_DIR)/src/drivers/timer/hw/zynq
+
+include $(REP_DIR)/lib/mk/timer.inc

--- a/repos/os/lib/mk/hw_zedboard/timer.mk
+++ b/repos/os/lib/mk/hw_zedboard/timer.mk
@@ -1,0 +1,3 @@
+INC_DIR += $(REP_DIR)/src/drivers/timer/hw $(REP_DIR)/src/drivers/timer/hw/zynq
+
+include $(REP_DIR)/lib/mk/timer.inc

--- a/repos/os/lib/mk/hw_zynq/timer.mk
+++ b/repos/os/lib/mk/hw_zynq/timer.mk
@@ -1,0 +1,3 @@
+INC_DIR += $(REP_DIR)/src/drivers/timer/hw $(REP_DIR)/src/drivers/timer/hw/zynq
+
+include $(REP_DIR)/lib/mk/timer.inc

--- a/repos/os/run/network_test_nic.inc
+++ b/repos/os/run/network_test_nic.inc
@@ -3,6 +3,18 @@
 # \author Alexander Boettcher
 # \date   2013-03-26
 #
+# After qemu is started the following steps
+# have to be done for configuriering the tap device
+# $ sudo brctl addbr br0
+# $ sudo ip link set tap0 master br0
+# $ sudo ifconfig tap0 0.0.0.0 up
+#
+# After this the nic can be tested with
+# $ ./bin/nic_drv_test_client tap0 52:54:00:12:34:56 256 5
+# $ ./bin/nic_drv_test_client tap0 FF:FF:FF:FF:FF:FF 256 5
+# $ ./bin/nic_drv_test_client tap0 bc:9a:78:56:34:12 256 5
+
+
 
 if {[expr [have_spec linux] || [have_spec hw_odroid_xu]]} {
 	puts "Run script not supported for this platform."; exit 0 }
@@ -36,6 +48,8 @@ if {[expr $use_nic_client && ![have_spec omap4] && ![have_spec platform_arndale]
 	set network_driver "nic_drv" }
 if {[expr !$use_nic_client && ![have_spec omap4] && ![have_spec platform_arndale]]} {
 	set network_driver "nic_drv_stat" }
+if {[have_spec cadence_gem]} {
+	set network_driver "nic_drv" }
 
 build $build_components
 
@@ -173,6 +187,17 @@ if {![regexp cap_net_raw $cap_rights]} {
 	eval "exec $sudo_command"
 }
 
+
+# set nic configuration for qemu depending on used hardware
+append_if [have_spec x86]     qemu_args " -net nic,model=e1000"
+append_if [have_spec lan9118] qemu_args " -net nic,model=lan9118"
+append_if [have_spec cadence_gem] qemu_args " -net nic,model=cadence_gem"
+
+# using a tap device for make it possible to
+# testing the application with raw ethernet packages
+append qemu_args " -net tap -nographic"
+
+
 #
 # Execute test case
 #
@@ -185,6 +210,7 @@ if {[expr [have_spec omap4] || [have_spec platform_arndale]]} {
 
 	sleep 10
 } else {
+run_genode_until forever
 	set match_string {--- get MAC address }
 	run_genode_until "$match_string.*\n" 30
 	set serial_id $spawn_id

--- a/repos/os/src/drivers/gpio/zynq/driver.h
+++ b/repos/os/src/drivers/gpio/zynq/driver.h
@@ -1,0 +1,76 @@
+/*
+ * \brief  Gpio Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-03-12
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _DRIVER_H_
+#define _DRIVER_H_
+
+#include <io_mem_session/connection.h>
+#include <timer_session/connection.h>
+#include <util/mmio.h>
+#include <vector>
+#include <new>
+#include <platform/zynq/drivers/board_base.h>
+#include "gpio.h"
+
+namespace Gpio {
+	using namespace Genode;
+	class Driver;
+}
+
+class Gpio::Driver
+{
+    private:
+
+        std::vector<Zynq_Gpio*> _gpio_bank;
+
+        Driver(std::vector<Genode::addr_t> addr)
+        {
+            for (unsigned i = 0; i < addr.size(); i++)
+            {
+                _gpio_bank.push_back(new Zynq_Gpio(addr[i], Genode::Board_base::GPIO_MMIO_SIZE));
+            }
+        }
+
+        ~Driver()
+        {
+            for (std::vector<Zynq_Gpio*>::iterator it = _gpio_bank.begin() ; it != _gpio_bank.end(); ++it)
+            {
+                delete (*it);
+            }
+            _gpio_bank.clear();
+        }
+
+	public:
+
+        static Driver& factory(std::vector<Genode::addr_t> addr);
+
+        Genode::uint8_t read(unsigned gpio, bool isChannel2)
+        {
+            Zynq_Gpio *gpio_reg = _gpio_bank[gpio];
+            return gpio_reg->gpio_read(isChannel2);
+        }
+
+        bool write(unsigned gpio, Genode::uint8_t data, bool isChannel2)
+        {
+            Zynq_Gpio *gpio_reg = _gpio_bank[gpio];
+            return gpio_reg->gpio_write(data, isChannel2);
+        }
+};
+
+Gpio::Driver& Gpio::Driver::factory(std::vector<Genode::addr_t> addr)
+{
+    static Gpio::Driver driver(addr);
+    return driver;
+}
+
+#endif /* _DRIVER_H_ */

--- a/repos/os/src/drivers/gpio/zynq/gpio.h
+++ b/repos/os/src/drivers/gpio/zynq/gpio.h
@@ -1,0 +1,98 @@
+/*
+ * \brief  Gpio Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-04-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _GPIO_H_
+#define _GPIO_H_
+
+#include <os/attached_io_mem_dataspace.h>
+#include <util/mmio.h>
+
+namespace Gpio {
+	using namespace Genode;
+    class Zynq_Gpio;
+}
+
+struct Gpio::Zynq_Gpio : Attached_io_mem_dataspace, Mmio
+{
+    Zynq_Gpio(Genode::addr_t const mmio_base, Genode::size_t const mmio_size) :
+		Genode::Attached_io_mem_dataspace(mmio_base, mmio_size),
+	  	Genode::Mmio((Genode::addr_t)local_addr<void>())
+    { }
+
+    ~Zynq_Gpio()
+    { }
+
+	/*
+	 * Registers
+	 */
+
+    struct GPIO_DATA : Register<0x00, 32> {};
+
+    struct GPIO_TRI : Register<0x04, 32> {};
+
+    struct GPIO2_DATA : Register<0x08, 32> {};
+
+    struct GPIO2_TRI : Register<0x0C, 32> {};
+
+    struct GIER : Register<0x011C, 32>
+    {
+        struct Global_Interrupt_Enable : Bitfield<31,1> {};
+    };
+
+    struct IP_IER : Register<0x0128, 32>
+    {
+        struct Channel_1_Interrupt_Enable : Bitfield<0,1> {};
+        struct Channel_2_Interrupt_Enable : Bitfield<1,1> {};
+    };
+
+    struct IP_ISR : Register<0x120, 32>
+    {
+        struct Channel_1_Interrupt_Status : Bitfield<0,1> {};
+        struct Channel_2_Interrupt_Status : Bitfield<1,1> {};
+    };
+
+
+    /*
+     * Functions
+     */
+    Genode::uint8_t gpio_read(bool isChannel2)
+    {
+        if (isChannel2)
+        {
+            write<GPIO2_TRI>(0xffffffff);
+            return read<GPIO2_DATA>();
+        }
+        else
+        {
+            write<GPIO_TRI>(0xffffffff);
+            return read<GPIO_DATA>();
+        }
+    }
+
+    bool gpio_write(Genode::uint8_t data, bool isChannel2)
+    {
+        if (isChannel2)
+        {
+            write<GPIO2_TRI>(0);
+            write<GPIO2_DATA>(data);
+        }
+        else
+        {
+            write<GPIO_TRI>(0);
+            write<GPIO_DATA>(data);
+        }
+        return true;
+    }
+};
+
+#endif // _GPIO_H_

--- a/repos/os/src/drivers/gpio/zynq/main.cc
+++ b/repos/os/src/drivers/gpio/zynq/main.cc
@@ -1,0 +1,132 @@
+/*
+ * \brief  Gpio Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-03-30
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#include <gpio_session/zynq/gpio_session.h>
+#include <cap_session/connection.h>
+#include <dataspace/client.h>
+#include <base/printf.h>
+#include <base/sleep.h>
+#include <root/component.h>
+#include <os/static_root.h>
+#include <os/config.h>
+#include <vector>
+#include "driver.h"
+
+namespace Gpio {
+	using namespace Genode;
+	class Session_component;
+	class Root;
+};
+
+class Gpio::Session_component : public Genode::Rpc_object<Gpio::Session>
+{
+	private:
+
+		Driver &_driver;
+        unsigned _number;
+
+	public:
+
+        Session_component(Driver &driver, unsigned gpio_number) : _driver(driver), _number(gpio_number) {}
+
+        virtual Genode::uint32_t read(bool isChannel2)
+		{
+            return _driver.read(_number, isChannel2);
+		}
+
+        virtual bool write(Genode::uint32_t data, bool isChannel2)
+		{
+            return _driver.write(_number, data, isChannel2);
+		}
+};
+
+class Gpio::Root : public Genode::Root_component<Gpio::Session_component>
+{
+	private:
+
+		Driver &_driver;
+
+	protected:
+
+		Session_component *_create_session(const char *args)
+		{
+            unsigned number = Genode::Arg_string::find_arg(args, "gpio").ulong_value(0);
+            Genode::size_t ram_quota = Genode::Arg_string::find_arg(args, "ram_quota").ulong_value(0);
+
+            if (ram_quota < sizeof(Session_component)) {
+                PWRN("Insufficient dontated ram_quota (%zd bytes), require %zd bytes",
+                     ram_quota, sizeof(Session_component));
+                throw Genode::Root::Quota_exceeded();
+            }
+
+            return new (md_alloc()) Session_component(_driver, number);
+		}
+
+	public:
+
+		Root(Genode::Rpc_entrypoint *session_ep,
+		     Genode::Allocator *md_alloc, Driver &driver)
+        : Genode::Root_component<Gpio::Session_component>(session_ep, md_alloc),
+		  _driver(driver) { }
+};
+
+int main(int, char **)
+{
+    using namespace Gpio;
+
+    PINF("Zynq Gpio driver");
+
+    /*
+     * Read config
+     */
+    std::vector<Genode::addr_t> addr;
+
+    try {
+        Genode::Xml_node gpio_node = Genode::config()->xml_node().sub_node("gpio");
+
+        for (unsigned i = 0; ;i++, gpio_node = gpio_node.next("gpio"))
+        {
+            addr.push_back(0);
+            gpio_node.attribute("addr").value(&addr[i]);
+            PINF("Gpio with mio address 0x%x added.", (unsigned int)addr[i]);
+
+            if (gpio_node.is_last("gpio")) break;
+        }
+    }
+    catch (Genode::Xml_node::Nonexistent_sub_node) {
+        PWRN("No Gpio config");
+    }
+
+    /*
+     * Create Driver
+     */
+    Driver &driver = Driver::factory(addr);
+    addr.clear();
+
+	/*
+	 * Initialize server entry point
+	 */
+    enum { STACK_SIZE = 4096 };
+	static Cap_connection cap;
+	Sliced_heap sliced_heap(env()->ram_session(), env()->rm_session());
+    static Rpc_entrypoint ep(&cap, STACK_SIZE, "gpio_ep");
+    static Gpio::Root gpio_root(&ep, &sliced_heap, driver);
+
+	/*
+	 * Announce service
+     */
+    env()->parent()->announce(ep.manage(&gpio_root));
+
+	Genode::sleep_forever();
+	return 0;
+}

--- a/repos/os/src/drivers/gpio/zynq/target.mk
+++ b/repos/os/src/drivers/gpio/zynq/target.mk
@@ -1,0 +1,12 @@
+# \brief  Gpio specific for zynq systems
+# \author Mark Albers
+# \date   2015-03-30
+
+TARGET   = zynq_gpio_drv
+
+SRC_CC   = main.cc
+LIBS     = base config libc libm stdcxx
+INC_DIR += $(PRG_DIR)
+
+vpath main.cc $(PRG_DIR)
+

--- a/repos/os/src/drivers/i2c/zynq/driver.h
+++ b/repos/os/src/drivers/i2c/zynq/driver.h
@@ -1,0 +1,100 @@
+/*
+ * \brief  I2C Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-03-12
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _DRIVER_H_
+#define _DRIVER_H_
+
+#include <io_mem_session/connection.h>
+#include <timer_session/connection.h>
+#include <util/mmio.h>
+
+#include <platform/zynq/drivers/board_base.h>
+
+#include "i2c.h"
+
+namespace I2C {
+	using namespace Genode;
+	class Driver;
+}
+
+class I2C::Driver
+{
+	private:
+		class I2C_bank
+		{
+		private:
+			Zynq_I2C _i2c;
+
+		public:
+
+			I2C_bank(Genode::addr_t base, Genode::size_t size) : _i2c(base, size) {	}
+
+			Zynq_I2C* regs() { return &_i2c; }
+		};
+
+		static I2C_bank _i2c_bank[2];
+
+		Driver() {}
+		~Driver() {}
+
+	public:
+		static Driver& factory();
+
+		bool read_byte_16bit_reg(unsigned bus, Genode::uint8_t adr, Genode::uint16_t reg, Genode::uint8_t *data)
+		{
+			Zynq_I2C *i2c_reg = _i2c_bank[bus].regs();
+			Genode::uint8_t buf[2];
+			buf[0]=reg >> 8;
+			buf[1]=reg;
+			if (i2c_reg->i2c_write(adr, buf, 2) != 0) 
+			{
+				PERR("Zynq i2c: read failed");
+				return false;
+			}
+			if (i2c_reg->i2c_read_byte(adr, data) != 0) 
+			{
+				PERR("Zynq i2c: read failed");
+				return false;
+			}
+			return true;
+		}
+
+		bool write_16bit_reg(unsigned bus, Genode::uint8_t adr, Genode::uint16_t reg,
+			Genode::uint8_t data)
+		{
+			Zynq_I2C *i2c_reg = _i2c_bank[bus].regs();
+			Genode::uint8_t buf[3];
+			buf[0]=reg >> 8;
+			buf[1]=reg;
+			buf[2]=data;
+			if (i2c_reg->i2c_write(adr, buf, 3) != 0) 
+			{
+				PERR("Zynq i2c: write failed");
+				return false;
+			}
+			return true;
+		}
+};
+
+I2C::Driver::I2C_bank I2C::Driver::_i2c_bank[2] = {
+	{Genode::Board_base::I2C0_MMIO_BASE, Genode::Board_base::I2C_MMIO_SIZE},
+	{Genode::Board_base::I2C1_MMIO_BASE, Genode::Board_base::I2C_MMIO_SIZE},
+};
+
+I2C::Driver& I2C::Driver::factory()
+{
+	static I2C::Driver driver;
+	return driver;
+}
+
+#endif /* _DRIVER_H_ */

--- a/repos/os/src/drivers/i2c/zynq/i2c.h
+++ b/repos/os/src/drivers/i2c/zynq/i2c.h
@@ -1,0 +1,333 @@
+/*
+ * \brief  I2C Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-03-12
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _I2C_H_
+#define _I2C_H_
+
+#include <os/attached_io_mem_dataspace.h>
+#include <util/mmio.h>
+
+/* Transfer direction */
+#define SENDING	0
+#define RECEIVING 1
+
+/* Interrupt masks */
+#define INTERRUPT_ARB_LOST_MASK  0x00000200
+#define INTERRUPT_RX_UNF_MASK    0x00000080
+#define INTERRUPT_TX_OVR_MASK    0x00000040
+#define INTERRUPT_RX_OVR_MASK    0x00000020
+#define INTERRUPT_SLV_RDY_MASK   0x00000010
+#define INTERRUPT_TO_MASK        0x00000008
+#define INTERRUPT_NACK_MASK      0x00000004
+#define INTERRUPT_DATA_MASK      0x00000002
+#define INTERRUPT_COMP_MASK      0x00000001
+#define ALL_INTERRUPTS_MASK     0x000002FF
+
+/* Maximal transfer size */
+#define I2C_MAX_TRANSFER_SIZE 252
+
+/* FIFO size */
+#define I2C_FIFO_DEPTH 16
+
+/* Number of bytes at data intr */
+#define I2C_DATA_INTR_DEPTH 14
+
+namespace I2C {
+	using namespace Genode;
+	class Zynq_I2C;
+}
+
+struct I2C::Zynq_I2C : Attached_io_mem_dataspace, Mmio
+{
+	Zynq_I2C(Genode::addr_t const mmio_base, Genode::size_t const mmio_size) :
+		Genode::Attached_io_mem_dataspace(mmio_base, mmio_size),
+	  	Genode::Mmio((Genode::addr_t)local_addr<void>())
+	{
+
+	}
+
+	~Zynq_I2C() 
+	{
+	
+	}
+
+	/*
+	 * Registers
+	 */
+
+	struct Control : Register<0x0, 16>
+	{
+		struct divisor_a 	: Bitfield<14,2> {};
+		struct divisor_b 	: Bitfield<8,6> {};
+		struct CLR_FIFO	 	: Bitfield<6,1> {};
+		struct SLVMON	 	: Bitfield<5,1> {};
+		struct HOLD	 	: Bitfield<4,1> {};
+		struct ACK_EN	 	: Bitfield<3,1> {};
+		struct NEA	 	: Bitfield<2,1> {};
+		struct MS	 	: Bitfield<1,1> {};
+		struct RW	 	: Bitfield<0,1> {};
+	};
+
+	struct Status : Register<0x4, 16>
+	{
+		struct BA 		: Bitfield<8,1> {};
+		struct RXOVF 		: Bitfield<7,1> {};
+		struct TXDV 		: Bitfield<6,1> {};
+		struct RXDV 		: Bitfield<5,1> {};
+		struct RXRW 		: Bitfield<3,1> {};
+	};
+
+	struct I2C_address : Register<0x8, 16>
+	{
+		struct ADD 		: Bitfield<0,10> {};
+	};
+
+	struct I2C_data : Register<0xC, 16>
+	{
+		struct DATA 		: Bitfield<0,8> {};
+	};
+
+	struct Interrupt_status : Register<0x10, 16>
+	{
+		struct ARB_LOST 	: Bitfield<9,1> {};
+		struct RX_UNF 		: Bitfield<7,1> {};
+		struct TX_OVF 		: Bitfield<6,1> {};
+		struct RX_OVF 		: Bitfield<5,1> {};
+		struct SLV_RDY 		: Bitfield<4,1> {};
+		struct TO 		: Bitfield<3,1> {};
+		struct NACK 		: Bitfield<2,1> {};
+		struct DATA 		: Bitfield<1,1> {};
+		struct COMP 		: Bitfield<0,1> {};
+	};
+
+	struct Transfer_size : Register<0x14, 8>
+	{
+		struct SIZE		: Bitfield<0,8> {};
+	};
+
+	struct Slave_mon_pause : Register<0x18, 8>
+	{
+		struct PAUSE 		: Bitfield<0,4> {};
+	};
+
+	struct Time_out : Register<0x1C, 8>
+	{
+		struct TO 		: Bitfield<0,8> {};
+	};
+
+	struct Interrupt_mask : Register<0x20, 16>
+	{
+		struct ARB_LOST 	: Bitfield<9,1> {};
+		struct RX_UNF 		: Bitfield<7,1> {};
+		struct TX_OVF 		: Bitfield<6,1> {};
+		struct RX_OVF 		: Bitfield<5,1> {};
+		struct SLV_RDY 		: Bitfield<4,1> {};
+		struct TO 		: Bitfield<3,1> {};
+		struct NACK 		: Bitfield<2,1> {};
+		struct DATA 		: Bitfield<1,1> {};
+		struct COMP 		: Bitfield<0,1> {};
+	};
+
+	struct Interrupt_enable : Register<0x24, 16>
+	{
+		struct ARB_LOST 	: Bitfield<9,1> {};
+		struct RX_UNF 		: Bitfield<7,1> {};
+		struct TX_OVF 		: Bitfield<6,1> {};
+		struct RX_OVF 		: Bitfield<5,1> {};
+		struct SLV_RDY 		: Bitfield<4,1> {};
+		struct TO 		: Bitfield<3,1> {};
+		struct NACK 		: Bitfield<2,1> {};
+		struct DATA 		: Bitfield<1,1> {};
+		struct COMP 		: Bitfield<0,1> {};
+	};
+
+	struct Interrupt_disable : Register<0x28, 16>
+	{
+		struct ARB_LOST 	: Bitfield<9,1> {};
+		struct RX_UNF 		: Bitfield<7,1> {};
+		struct TX_OVF 		: Bitfield<6,1> {};
+		struct RX_OVF 		: Bitfield<5,1> {};
+		struct SLV_RDY 		: Bitfield<4,1> {};
+		struct TO 		: Bitfield<3,1> {};
+		struct NACK 		: Bitfield<2,1> {};
+		struct DATA 		: Bitfield<1,1> {};
+		struct COMP 		: Bitfield<0,1> {};
+	};
+
+
+	Timer::Connection _timer;
+	int sendByteCount;
+	uint8_t *sendBufferPtr;
+
+	void init(int direction)
+	{
+		write<Control>(	Control::divisor_a::bits(2) |
+				Control::divisor_b::bits(16) |
+				Control::ACK_EN::bits(1) |
+				Control::CLR_FIFO::bits(1) |
+				Control::NEA::bits(1) |
+				Control::MS::bits(1));
+	write<Control::RW>(direction);
+	}
+
+	void transmitFifoFill()
+	{
+		uint8_t availBytes;
+		int loopCnt;
+		int numBytesToSend;
+
+		/*
+		 * Determine number of bytes to write to FIFO.
+		 */
+		availBytes = I2C_FIFO_DEPTH - read<Transfer_size::SIZE>();
+		numBytesToSend = sendByteCount > availBytes ? availBytes : sendByteCount;
+
+		/*
+		 * Fill FIFO with amount determined above.
+		 */
+		for (loopCnt = 0; loopCnt < numBytesToSend; loopCnt++) 
+		{
+			write<I2C_data::DATA>(*sendBufferPtr);
+			sendBufferPtr++;
+			sendByteCount--;
+		}
+	}
+
+	int i2c_write(uint8_t slaveAddr, uint8_t *msgPtr, int byteCount)
+	{
+		uint32_t intrs, intrStatusReg;
+
+		sendByteCount = byteCount;
+		sendBufferPtr = msgPtr;
+
+		/*
+		 * Set HOLD bit if byteCount is bigger than FIFO.
+		 */
+		if (byteCount > I2C_FIFO_DEPTH) write<Control::HOLD>(1);
+
+		/*
+		 * Init sending master.
+		 */
+		init(SENDING);
+
+		/*
+		 * intrs keeps all the error-related interrupts.
+		 */
+		intrs = INTERRUPT_ARB_LOST_MASK | INTERRUPT_TX_OVR_MASK | INTERRUPT_NACK_MASK;
+		
+		/*
+		 * Clear the interrupt status register before use it to monitor.
+		 */
+		write<Interrupt_status>(read<Interrupt_status>());
+
+		/*
+		 * Transmit first FIFO full of data.
+		 */
+		transmitFifoFill();
+		write<I2C_address::ADD>(slaveAddr);
+		intrStatusReg = read<Interrupt_status>();
+			
+		/*
+		 * Continue sending as long as there is more data and there are no errors.
+		 */
+		while ((sendByteCount > 0) && ((intrStatusReg & intrs) == 0)) 
+		{
+			/*
+			 * Wait until transmit FIFO is empty.
+			 */
+			if (read<Status::TXDV>() != 0) 
+			{
+				intrStatusReg = read<Interrupt_status>();
+				continue;
+			}
+
+			/*
+			 * Send more data out through transmit FIFO.
+			 */
+			transmitFifoFill();
+		}
+
+		/*
+		 * Check for completion of transfer.
+		 */
+		while ((intrStatusReg & INTERRUPT_COMP_MASK) != INTERRUPT_COMP_MASK)
+		{
+
+			intrStatusReg = read<Interrupt_status>();
+			/*
+			 * If there is an error, tell the caller.
+			 */
+			if ((intrStatusReg & intrs) != 0) 
+			{
+				return 1;
+			}
+		}
+
+		write<Control::HOLD>(0);
+
+		return 0;
+	}
+
+	int i2c_read_byte(uint8_t slaveAddr, uint8_t *msgPtr)
+	{
+		uint32_t intrs, intrStatusReg;
+
+		/*
+		 * Init receiving master.
+		 */
+		init(RECEIVING);
+
+		/*
+		 * Clear the interrupt status register before use it to monitor.
+		 */
+		write<Interrupt_status>(read<Interrupt_status>());
+
+		/*
+		 * Set up the transfer size register so the slave knows how much
+		 * to send to us.
+		 */
+		write<Transfer_size::SIZE>(1);
+
+		/*
+		 * Set slave address.
+		 */
+		write<I2C_address::ADD>(slaveAddr);
+
+		/*
+		 * intrs keeps all the error-related interrupts.
+		 */
+		intrs = INTERRUPT_ARB_LOST_MASK | INTERRUPT_RX_OVR_MASK | 
+			INTERRUPT_RX_UNF_MASK | INTERRUPT_NACK_MASK;
+
+		/*
+		 * Poll the interrupt status register to find the errors.
+		 */
+		intrStatusReg = read<Interrupt_status>();
+
+		while (read<Status::RXDV>() != 1)
+		{
+			if (intrStatusReg & intrs) return 1;
+		}
+
+		if (intrStatusReg & intrs) return 1;
+
+		*msgPtr = read<I2C_data::DATA>();
+
+		while (read<Interrupt_status::COMP>() != 1) {}
+
+		return 0;
+	}
+
+};
+
+#endif // _I2C_H_

--- a/repos/os/src/drivers/i2c/zynq/main.cc
+++ b/repos/os/src/drivers/i2c/zynq/main.cc
@@ -1,0 +1,102 @@
+/*
+ * \brief  I2C Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-03-12
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#include <i2c_session/zynq/i2c_session.h>
+#include <cap_session/connection.h>
+#include <dataspace/client.h>
+#include <base/printf.h>
+#include <base/sleep.h>
+#include <root/component.h>
+
+#include <os/static_root.h>
+#include <os/config.h>
+
+#include "driver.h"
+
+namespace I2C {
+	using namespace Genode;
+	class Session_component;
+	class Root;
+};
+
+class I2C::Session_component : public Genode::Rpc_object<I2C::Session>
+{
+	private:
+		Driver &_driver;
+		unsigned int _bus;
+		Genode::Signal_context_capability _sigh;
+
+	public:
+
+		Session_component(Driver &driver, unsigned int bus_num) : _driver(driver), _bus(bus_num) {}
+
+		virtual bool read_byte_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg, Genode::uint8_t *data)
+		{
+			return _driver.read_byte_16bit_reg(_bus, adr, reg, data);
+		}
+
+		virtual bool write_16bit_reg(Genode::uint8_t adr, Genode::uint16_t reg,
+			Genode::uint8_t data)
+		{
+			return _driver.write_16bit_reg(_bus, adr, reg, data);
+		}
+};
+
+class I2C::Root : public Genode::Root_component<I2C::Session_component>
+{
+	private:
+
+		Driver &_driver;
+
+	protected:
+
+		Session_component *_create_session(const char *args)
+		{
+			unsigned int bus = Genode::Arg_string::find_arg(args, "bus").ulong_value(0);
+			return new (md_alloc()) Session_component(_driver, bus);
+		}
+
+	public:
+
+		Root(Genode::Rpc_entrypoint *session_ep,
+		     Genode::Allocator *md_alloc, Driver &driver)
+		: Genode::Root_component<I2C::Session_component>(session_ep, md_alloc),
+		  _driver(driver) { }
+};
+
+int main(int, char **)
+{
+	using namespace I2C;
+
+	PINF("Zynq I2C driver");
+
+	Driver &driver = Driver::factory();
+
+	/*
+	 * Initialize server entry point
+	 */
+	enum { STACK_SIZE = 4096 };
+	static Cap_connection cap;
+	Sliced_heap sliced_heap(env()->ram_session(), env()->rm_session());
+	static Rpc_entrypoint ep(&cap, STACK_SIZE, "i2c_ep");
+	static I2C::Root i2c_root(&ep, &sliced_heap, driver);
+
+	/*
+	 * Announce service
+	 */
+	env()->parent()->announce(ep.manage(&i2c_root));
+
+	Genode::sleep_forever();
+	return 0;
+}
+

--- a/repos/os/src/drivers/i2c/zynq/target.mk
+++ b/repos/os/src/drivers/i2c/zynq/target.mk
@@ -1,0 +1,12 @@
+# \brief  I2C specific for zynq systems
+# \author Mark Albers
+# \date   2015-03-12
+
+TARGET   = zynq_i2c_drv
+
+SRC_CC   = main.cc
+LIBS     = base config
+INC_DIR += $(PRG_DIR)
+
+vpath main.cc $(PRG_DIR)
+

--- a/repos/os/src/drivers/nic/gem/buffer_descriptor.h
+++ b/repos/os/src/drivers/nic/gem/buffer_descriptor.h
@@ -1,0 +1,103 @@
+/*
+ * \brief  Base EMAC driver for the Xilinx EMAC PS used on Zynq devices
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__BUFFER_DESCRIPTOR_H_
+#define _INCLUDE__DRIVERS__NIC__BUFFER_DESCRIPTOR_H_
+
+/* Genode includes */
+#include <os/attached_ram_dataspace.h>
+#include <util/mmio.h>
+
+using namespace Genode;
+
+
+class Buffer_descriptor : protected Attached_ram_dataspace, protected Mmio
+{
+	public:
+		static const size_t BUFFER_DESC_SIZE = 0x08;
+		static const size_t MAX_PACKAGE_SIZE = 1600;
+		static const size_t BUFFER_SIZE = BUFFER_DESC_SIZE + MAX_PACKAGE_SIZE;
+
+	private:
+		const size_t _buffer_count;
+		const size_t _buffer_offset;
+
+		unsigned int _descriptor_index;
+		char* const _buffer;
+
+	protected:
+		typedef struct {
+			uint32_t addr;
+			uint32_t status;
+		} descriptor_t;
+
+		descriptor_t* const _descriptors;
+
+
+
+		void _increment_descriptor_index()
+		{
+			_descriptor_index++;
+			_descriptor_index %= _buffer_count;
+		}
+
+
+		descriptor_t& _current_descriptor()
+		{
+			return _descriptors[_descriptor_index];
+		}
+
+
+		char* const _current_buffer()
+		{
+			char* const buffer = &_buffer[MAX_PACKAGE_SIZE * _descriptor_index];
+			return buffer;
+		}
+
+
+	public:
+		/*
+		 * start of the ram spave contains all buffer descriptors
+		 * after that the data spaces for the ethernet packages are following
+		 */
+		Buffer_descriptor(const size_t buffer_count = 1) :
+			Attached_ram_dataspace(env()->ram_session(), BUFFER_SIZE * buffer_count, UNCACHED),
+			Genode::Mmio( reinterpret_cast<addr_t>(local_addr<void>()) ),
+			_buffer_count(buffer_count),
+			_buffer_offset(BUFFER_DESC_SIZE * buffer_count),
+			_descriptor_index(0),
+			_buffer(local_addr<char>() + _buffer_offset),
+			_descriptors(local_addr<descriptor_t>())
+		{
+			/*
+			 * Save address of _buffer.
+			 * Has to be the physical address and not the virtual addresse,
+			 * because the dma controller of the nic will use it.
+			 * Ignore lower two bits,
+			 * because this are status bits.
+			 */
+			for (unsigned int i=0; i<buffer_count; i++) {
+				_descriptors[i].addr = (phys_addr_buffer(i)) & ~0x3;
+			}
+		}
+
+
+		addr_t phys_addr() { return Dataspace_client(cap()).phys_addr(); }
+
+		addr_t phys_addr_buffer(const unsigned int index)
+		{
+			return phys_addr() + _buffer_offset + MAX_PACKAGE_SIZE * index;
+		}
+};
+
+#endif /* _INCLUDE__DRIVERS__NIC__BUFFER_DESCRIPTOR_H_ */

--- a/repos/os/src/drivers/nic/gem/cadence_gem.h
+++ b/repos/os/src/drivers/nic/gem/cadence_gem.h
@@ -1,0 +1,538 @@
+/*
+ * \brief  Base EMAC driver for the Xilinx EMAC PS used on Zynq devices
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__XILINX_EMACPS_BASE_H_
+#define _INCLUDE__DRIVERS__NIC__XILINX_EMACPS_BASE_H_
+
+/* Genode includes */
+#include <os/attached_mmio.h>
+#include <nic_session/nic_session.h>
+#include <nic/driver.h>
+#include <timer_session/connection.h>
+
+#include "system_control.h"
+#include "tx_buffer_descriptor.h"
+#include "rx_buffer_descriptor.h"
+#include "marvell_phy.h"
+
+
+namespace Genode
+{
+	/**
+	 * Base driver Xilinx EMAC PS module
+	 */
+	class Cadence_gem : private Genode::Attached_mmio, public Nic::Driver, public Phyio
+	{
+		private:
+			/**
+			* Control register
+			*/
+			struct Control : Register<0x00, 32>
+			{
+				struct Local_loopback  : Bitfield<1, 1> {};
+				struct Rx_en  : Bitfield<2, 1> {};
+				struct Tx_en  : Bitfield<3, 1> {};
+				struct Mgmt_port_en  : Bitfield<4, 1> {};
+				struct Clear_statistics  : Bitfield<5, 1> {};
+				struct Start_tx  : Bitfield<9, 1> {};
+
+				static access_t init() {
+					return Mgmt_port_en::bits(1) |
+						Tx_en::bits(1) |
+						Rx_en::bits(1);
+				}
+
+				static access_t start_tx() {
+					return (init() | Start_tx::bits(1));
+				}
+			};
+
+			/**
+			* Config register
+			*/
+			struct Config : Register<0x04, 32>
+			{
+				struct Speed_100  : Bitfield<0, 1> {};
+				struct Full_duplex  : Bitfield<1, 1> {};
+				struct Copy_all  : Bitfield<4, 1> {};
+				struct No_broadcast  : Bitfield<5, 1> {};
+				struct Multi_hash_en  : Bitfield<6, 1> {};
+				struct Gige_en  : Bitfield<10, 1> {};
+				struct Fcs_remove  : Bitfield<17, 1> {};
+				struct Mdc_clk_div  : Bitfield<18, 3> {
+					enum {
+						DIV_32 = 0b010,
+						DIV_224 = 0b111,
+					};
+				};
+				struct Ignore_rx_fcs  : Bitfield<26, 1> {};
+			};
+
+			/**
+			* Status register
+			*/
+			struct Status : Register<0x08, 32>
+			{
+				struct Phy_mgmt_idle  : Bitfield<2, 1> {};
+			};
+
+
+
+			/**
+			* DMA Config register
+			*/
+			struct Dma_config : Register<0x10, 32>
+			{
+				struct Rx_pktbuf_memsz_sel  : Bitfield<8, 2> {
+					enum {
+						SPACE_8KB = 0x3,
+					};
+				};
+				struct Tx_pktbuf_memsz_sel  : Bitfield<10, 1> {
+					enum {
+						SPACE_4KB = 0x1,
+					};
+				};
+				struct Ahb_mem_rx_buf_size  : Bitfield<16, 8> {
+					enum {
+						BUFFER_1600B = 0x19,
+					};
+				};
+
+				static access_t init()
+				{
+					return Ahb_mem_rx_buf_size::bits(Ahb_mem_rx_buf_size::BUFFER_1600B) |
+						Rx_pktbuf_memsz_sel::bits(Rx_pktbuf_memsz_sel::SPACE_8KB) |
+						Tx_pktbuf_memsz_sel::bits(Tx_pktbuf_memsz_sel::SPACE_4KB);
+				}
+
+				// TODO possibly enable transmition check sum offloading
+			};
+
+			/**
+			* Tx_Status register
+			*/
+			struct Tx_status : Register<0x14, 32>
+			{
+				struct Tx_complete  : Bitfield<5, 1> {};
+				struct Tx_go  : Bitfield<3, 1> {};
+			};
+
+			/**
+			* Receiving queue base addresse register
+			*/
+			struct Rx_qbar : Register<0x18, 32>
+			{
+				struct Addr : Bitfield<0, 32> {};
+			};
+
+			/**
+			* Transmition queue base addresse register
+			*/
+			struct Tx_qbar : Register<0x1C, 32>
+			{
+				struct Addr : Bitfield<0, 32> {};
+			};
+
+
+			/**
+			* Receive status register
+			*/
+			struct Rx_status : Register<0x20, 32>
+			{
+				struct Frame_reveived : Bitfield<1, 1> {};
+				struct Buffer_not_available : Bitfield<0, 1> {};
+			};
+
+
+			/**
+			* Interrupt status register
+			*/
+			struct Interrupt_status : Register<0x24, 32>
+			{
+				struct Rx_used_read : Bitfield<3, 1> {};
+				struct Rx_complete : Bitfield<1, 1> {};
+			};
+
+
+			/**
+			* Interrupt enable register
+			*/
+			struct Interrupt_enable : Register<0x28, 32>
+			{
+				struct Rx_complete : Bitfield<1, 1> {};
+			};
+
+
+			/**
+			* Interrupt disable register
+			*/
+			struct Interrupt_disable : Register<0x2C, 32>
+			{
+				struct Rx_complete : Bitfield<1, 1> {};
+			};
+
+
+			/**
+			* PHY maintenance register
+			*/
+			struct Phy_maintenance : Register<0x34, 32>
+			{
+				struct Clause_22 : Bitfield<30, 1> {};
+				struct Operation : Bitfield<28, 2> {
+					enum Type {
+						READ = 0b10,
+						WRITE = 0b01
+					};
+				};
+				struct Phy_addr : Bitfield<23, 5> {};
+				struct Reg_addr : Bitfield<18, 5> {};
+				struct Must_10 : Bitfield<16, 2> {
+					enum { INIT = 0b10 };
+				};
+				struct Data : Bitfield<0, 16> {};
+			};
+
+
+			/**
+			* MAC hash register
+			*/
+			struct Hash_register : Register<0x80, 64>
+			{
+				struct Low_hash   : Bitfield<0, 32> { };
+				struct High_hash   : Bitfield<32, 16> { };
+			};
+
+
+			/**
+			* MAC Addresse
+			*/
+			struct Mac_addr_1 : Register<0x88, 64>
+			{
+				struct Low_addr   : Bitfield<0, 32> { };
+				struct High_addr   : Bitfield<32, 16> { };
+			};
+
+
+			/**
+			* Counter for the successfully transmitted frames
+			*/
+			struct Frames_transmitted : Register<0x108, 32>
+			{
+				struct Counter : Bitfield<0, 32> { };
+			};
+
+
+			/**
+			* Counter for the successfully received frames
+			*/
+			struct Frames_received : Register<0x158, 32>
+			{
+				struct Counter : Bitfield<0, 32> { };
+			};
+
+
+			/**
+			* Counter for the successfully received frames
+			*/
+			struct Rx_overrun_errors : Register<0x1A4, 32>
+			{
+				struct Counter : Bitfield<0, 10> { };
+			};
+
+
+			class Phy_timeout_for_idle : public Genode::Exception {};
+			class Unkown_ethernet_speed : public Genode::Exception {};
+
+
+			Timer::Connection _timer;
+
+			System_control _sys_ctrl;
+			Tx_buffer_descriptor _tx_buffer;
+			Rx_buffer_descriptor _rx_buffer;
+
+			Nic::Rx_buffer_alloc& _rx_buffer_alloc;
+			Nic::Driver_notification &_notify;
+
+			enum { IRQ_STACK_SIZE = 4096 };
+			const Genode::Irq_activation _irq_activation;
+
+			Marvel_phy _phy;
+
+
+			void _init()
+			{
+				// TODO checksum offloading and pause frames
+				/* see 16.3.2 Configure the Controller */
+
+				/* 1. Program the Network Configuration register (gem.net_cfg) */
+				write<Config>(
+					Config::Speed_100::bits(1) |
+					Config::Full_duplex::bits(1) |
+					Config::Multi_hash_en::bits(1) |
+					Config::Mdc_clk_div::bits(Config::Mdc_clk_div::DIV_32) |
+					Config::Fcs_remove::bits(1)
+				);
+
+
+				/* 2. set mac address */
+				Nic::Mac_address mac;
+				mac.addr[5] = 0x12;
+				mac.addr[4] = 0x34;
+				mac.addr[3] = 0x56;
+				mac.addr[2] = 0x78;
+				mac.addr[1] = 0x9A;
+				mac.addr[0] = 0xBC;
+				mac_address(mac);
+
+
+				write<Rx_qbar>( _rx_buffer.phys_addr() );
+				write<Tx_qbar>( _tx_buffer.phys_addr() );
+
+
+				/* 3. Program the DMA Configuration register (gem.dma_cfg) */
+				write<Dma_config>( Dma_config::init() );
+
+
+				/*
+				 * 4. Program the Network Control Register (gem.net_ctrl)
+				 * Enable MDIO, transmitter and receiver
+				 */
+				write<Control>(Control::init());
+
+
+
+				_phy.init();
+
+				/* change emac clocks depending on phy autonegation result */
+				uint32_t rclk = 0;
+				uint32_t clk = 0;
+				switch (_phy.eth_speed()) {
+				case SPEED_1000:
+					write<Config::Gige_en>(1);
+					rclk = (0 << 4) | (1 << 0);
+					clk = (1 << 20) | (8 << 8) | (0 << 4) | (1 << 0);
+					break;
+				case SPEED_100:
+					write<Config::Gige_en>(0);
+					write<Config::Speed_100>(1);
+					rclk = 1 << 0;
+					clk = (5 << 20) | (8 << 8) | (0 << 4) | (1 << 0);
+					break;
+				case SPEED_10:
+					write<Config::Gige_en>(0);
+					write<Config::Speed_100>(0);
+					rclk = 1 << 0;
+					/* FIXME untested */
+					clk = (5 << 20) | (8 << 8) | (0 << 4) | (1 << 0);
+					break;
+				default:
+					throw Unkown_ethernet_speed();
+				}
+				_sys_ctrl.set_clk(clk, rclk);
+
+
+				/* 16.3.6 Configure Interrupts */
+				write<Interrupt_enable>(Interrupt_enable::Rx_complete::bits(1));
+			}
+
+			void _deinit()
+			{
+				/* 16.3.1 Initialize the Controller */
+
+				/* Disable all interrupts */
+				write<Interrupt_disable>(0x7FFFEFF);
+
+				/* Disable the receiver & transmitter */
+				write<Control>(0);
+				write<Control>(Control::Clear_statistics::bits(1));
+
+				write<Tx_status>(0xFF);
+				write<Rx_status>(0x0F);
+				write<Phy_maintenance>(0);
+
+				write<Rx_qbar>(0);
+				write<Tx_qbar>(0);
+
+				/* Clear the Hash registers for the mac address
+				 * pointed by AddressPtr
+				 */
+				write<Hash_register>(0);
+			}
+
+
+			void _mdio_wait()
+			{
+				uint32_t timeout = 200;
+
+				/* Wait till MDIO interface is ready to accept a new transaction. */
+				while (!read<Status::Phy_mgmt_idle>()) {
+					if (timeout <= 0) {
+						PWRN("%s: Timeout\n", __func__);
+						throw Phy_timeout_for_idle();
+					}
+
+					_timer.msleep(1);
+					timeout--;
+				}
+			}
+
+
+			void _phy_setup_op(const uint8_t phyaddr, const uint8_t regnum, const uint16_t data, const Phy_maintenance::Operation::Type op)
+			{
+				_mdio_wait();
+
+				/* Write mgtcr and wait for completion */
+				write<Phy_maintenance>(
+							Phy_maintenance::Clause_22::bits(1) |
+							Phy_maintenance::Operation::bits(op) |
+							Phy_maintenance::Phy_addr::bits(phyaddr) |
+							Phy_maintenance::Reg_addr::bits(regnum) |
+							Phy_maintenance::Must_10::bits(Phy_maintenance::Must_10::INIT) |
+							Phy_maintenance::Data::bits(data) );
+
+				_mdio_wait();
+			}
+
+
+		public:
+			/**
+			 * Constructor
+			 *
+			 * \param  base       MMIO base address
+			 */
+			Cadence_gem(addr_t const base, size_t const size, const int irq, Nic::Rx_buffer_alloc& alloc,
+		             Nic::Driver_notification &notify) :
+				Genode::Attached_mmio(base, size),
+				_rx_buffer_alloc(alloc),
+				_notify(notify),
+				_irq_activation(irq, *this, IRQ_STACK_SIZE),
+				_phy(*this)
+			{
+				_deinit();
+				_init();
+			}
+
+			~Cadence_gem()
+			{
+				// TODO dsiable tx and rx and clean up irq registration
+				_deinit();
+			}
+
+
+			void phy_write(const uint8_t phyaddr, const uint8_t regnum, const uint16_t data)
+			{
+				_phy_setup_op(phyaddr, regnum, data, Phy_maintenance::Operation::WRITE);
+			}
+
+
+			void phy_read(const uint8_t phyaddr, const uint8_t regnum, uint16_t& data)
+			{
+				_phy_setup_op(phyaddr, regnum, 0, Phy_maintenance::Operation::READ);
+
+				data = read<Phy_maintenance::Data>();
+			}
+
+
+			void mac_address(const Nic::Mac_address mac)
+			{
+				const uint32_t* const low_addr_pointer = reinterpret_cast<const uint32_t*>(&mac.addr[0]);
+				const uint16_t* const high_addr_pointer = reinterpret_cast<const uint16_t*>(&mac.addr[4]);
+
+				write<Mac_addr_1::Low_addr>(*low_addr_pointer);
+				write<Mac_addr_1::High_addr>(*high_addr_pointer);
+			}
+
+			/***************************
+			 ** Nic::Driver interface **
+			 ***************************/
+
+			virtual Nic::Mac_address mac_address()
+			{
+				Nic::Mac_address mac;
+				uint32_t* const low_addr_pointer = reinterpret_cast<uint32_t*>(&mac.addr[0]);
+				uint16_t* const high_addr_pointer = reinterpret_cast<uint16_t*>(&mac.addr[4]);
+
+				*low_addr_pointer = read<Mac_addr_1::Low_addr>();
+				*high_addr_pointer = read<Mac_addr_1::High_addr>();
+
+				return mac;
+			}
+
+			virtual bool link_state()
+			{
+				/* XXX return always true for now */
+				return true;
+			}
+
+			virtual void tx(char const *packet, Genode::size_t size)
+			{
+				_tx_buffer.add_to_queue(packet, size);
+				write<Control>(Control::start_tx());
+			}
+
+			/******************************
+			 ** Irq_activation interface **
+			 ******************************/
+
+			virtual void handle_irq(int irq_number)
+			{
+				/* 16.3.9 Receiving Frames */
+				/* read interrupt status, to detect the interrupt reasone */
+				const Interrupt_status::access_t status = read<Interrupt_status>();
+				const Rx_status::access_t rxStatus = read<Rx_status>();
+
+				if ( Interrupt_status::Rx_complete::get(status) ) {
+
+					while (_rx_buffer.package_available()) {
+						// TODO use this buffer directly as the destination for the DMA controller
+						// to minimize the overrun errors
+						const size_t buffer_size = _rx_buffer.package_length();
+						char* const buffer = static_cast<char*>( _rx_buffer_alloc.alloc(buffer_size) );
+						/*
+						 * copy data from rx buffer to new allocated buffer.
+						 * Has to be copied,
+						 * because the extern allocater possibly is using the cache.
+						 */
+						if ( _rx_buffer.get_package(buffer, buffer_size) != buffer_size ) {
+							PWRN("Package not fully copiied. Package ignored.");
+							return;
+						}
+
+						/* clearing error flags */
+						write<Interrupt_status::Rx_used_read>(1);
+						write<Rx_status::Buffer_not_available>(1);
+
+						/* comit buffer to system services */
+						_rx_buffer_alloc.submit();
+					}
+
+					/* check, if there was lost some packages */
+					const uint16_t lost_packages = read<Rx_overrun_errors::Counter>();
+					if (lost_packages > 0) {
+						PWRN("%d packages lost (%d packages successfully received)!",
+							 lost_packages, read<Frames_received>());
+					}
+
+					/* reset reveive complete interrupt */
+					write<Rx_status>(Rx_status::Frame_reveived::bits(1));
+					write<Interrupt_status>(Interrupt_status::Rx_complete::bits(1));
+				} else {
+					PWRN("IRQ %d with unkown reasone recevied (status: %08x).", irq_number, status);
+				}
+			}
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__NIC__XILINX_EMACPS_BASE_H_ */
+

--- a/repos/os/src/drivers/nic/gem/main.cc
+++ b/repos/os/src/drivers/nic/gem/main.cc
@@ -1,0 +1,63 @@
+/*
+ * \brief  EMACPS NIC driver for Xilix Zynq-7000
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+/* Genode includes */
+#include <base/sleep.h>
+#include <cap_session/connection.h>
+#include <nic/component.h>
+
+/* core includes */
+// TODO replace with #include <board.h>
+#include <drivers/board_base.h>
+
+#include "cadence_gem.h"
+
+
+int main(int, char **)
+{
+	using namespace Genode;
+
+	printf("--- Xilinx Ethernet MAC PS NIC driver started ---\n");
+
+	/**
+	 * Factory used by 'Nic::Root' at session creation/destruction time
+	 */
+	struct Emacps_driver_factory : Nic::Driver_factory
+	{
+		Nic::Driver *create(Nic::Rx_buffer_alloc &alloc,
+		                    Nic::Driver_notification &notify)
+		{
+			return new (env()->heap())
+				Cadence_gem(Board_base::EMAC_0_MMIO_BASE,
+								   Board_base::EMAC_0_MMIO_SIZE,
+								   Board_base::EMAC_0_IRQ,
+								   alloc, notify);
+		}
+
+		void destroy(Nic::Driver *driver)
+		{
+			Genode::destroy(env()->heap(), static_cast<Cadence_gem*>(driver));
+		}
+
+	} driver_factory;
+
+	enum { STACK_SIZE = 4096 };
+	static Cap_connection cap;
+	static Rpc_entrypoint ep(&cap, STACK_SIZE, "nic_ep");
+
+	static Nic::Root nic_root(&ep, env()->heap(), driver_factory);
+	env()->parent()->announce(ep.manage(&nic_root));
+
+	Genode::sleep_forever();
+	return 0;
+}

--- a/repos/os/src/drivers/nic/gem/marvell_phy.cc
+++ b/repos/os/src/drivers/nic/gem/marvell_phy.cc
@@ -1,0 +1,511 @@
+/*
+ * \brief  Phy driver for Marvell chips
+ * \author Timo Wischer
+ * \date   2015-05-11
+ */
+
+#include "marvell_phy.h"
+
+
+/* Generic MII registers. */
+#define MII_BMCR	    0x00	/* Basic mode control register */
+#define MII_BMSR	    0x01	/* Basic mode status register  */
+#define MII_PHYSID1	    0x02	/* PHYS ID 1		       */
+#define MII_PHYSID2	    0x03	/* PHYS ID 2		       */
+#define MII_ADVERTISE	    0x04	/* Advertisement control reg   */
+#define MII_LPA		    0x05	/* Link partner ability reg    */
+#define MII_EXPANSION	    0x06	/* Expansion register	       */
+#define MII_CTRL1000	    0x09	/* 1000BASE-T control	       */
+#define MII_STAT1000	    0x0a	/* 1000BASE-T status	       */
+#define MII_ESTATUS	    0x0f	/* Extended Status */
+#define MII_DCOUNTER	    0x12	/* Disconnect counter	       */
+#define MII_FCSCOUNTER	    0x13	/* False carrier counter       */
+#define MII_NWAYTEST	    0x14	/* N-way auto-neg test reg     */
+#define MII_RERRCOUNTER     0x15	/* Receive error counter       */
+#define MII_SREVISION	    0x16	/* Silicon revision	       */
+#define MII_RESV1	    0x17	/* Reserved...		       */
+#define MII_LBRERROR	    0x18	/* Lpback, rx, bypass error    */
+#define MII_PHYADDR	    0x19	/* PHY address		       */
+#define MII_RESV2	    0x1a	/* Reserved...		       */
+#define MII_TPISTATUS	    0x1b	/* TPI status for 10mbps       */
+#define MII_NCONFIG	    0x1c	/* Network interface config    */
+
+
+/* 88E1310 PHY defines */
+#define MIIM_88E1310_PHY_LED_CTRL	16
+#define MIIM_88E1310_PHY_IRQ_EN		18
+#define MIIM_88E1310_PHY_RGMII_CTRL	21
+#define MIIM_88E1310_PHY_PAGE		22
+
+
+/* Basic mode control register. */
+#define BMCR_RESV		0x003f	/* Unused...		       */
+#define BMCR_SPEED1000		0x0040	/* MSB of Speed (1000)	       */
+#define BMCR_CTST		0x0080	/* Collision test	       */
+#define BMCR_FULLDPLX		0x0100	/* Full duplex		       */
+#define BMCR_ANRESTART		0x0200	/* Auto negotiation restart    */
+#define BMCR_ISOLATE		0x0400	/* Disconnect DP83840 from MII */
+#define BMCR_PDOWN		0x0800	/* Powerdown the DP83840       */
+#define BMCR_ANENABLE		0x1000	/* Enable auto negotiation     */
+#define BMCR_SPEED100		0x2000	/* Select 100Mbps	       */
+#define BMCR_LOOPBACK		0x4000	/* TXD loopback bits	       */
+#define BMCR_RESET		0x8000	/* Reset the DP83840	       */
+
+/* Basic mode status register. */
+#define BMSR_ERCAP		0x0001	/* Ext-reg capability	       */
+#define BMSR_JCD		0x0002	/* Jabber detected	       */
+#define BMSR_LSTATUS		0x0004	/* Link status		       */
+#define BMSR_ANEGCAPABLE	0x0008	/* Able to do auto-negotiation */
+#define BMSR_RFAULT		0x0010	/* Remote fault detected       */
+#define BMSR_ANEGCOMPLETE	0x0020	/* Auto-negotiation complete   */
+#define BMSR_RESV		0x00c0	/* Unused...		       */
+#define BMSR_ESTATEN		0x0100	/* Extended Status in R15 */
+#define BMSR_100HALF2		0x0200	/* Can do 100BASE-T2 HDX */
+#define BMSR_100FULL2		0x0400	/* Can do 100BASE-T2 FDX */
+#define BMSR_10HALF		0x0800	/* Can do 10mbps, half-duplex  */
+#define BMSR_10FULL		0x1000	/* Can do 10mbps, full-duplex  */
+#define BMSR_100HALF		0x2000	/* Can do 100mbps, half-duplex */
+#define BMSR_100FULL		0x4000	/* Can do 100mbps, full-duplex */
+#define BMSR_100BASE4		0x8000	/* Can do 100mbps, 4k packets  */
+
+
+/* Advertisement control register. */
+#define ADVERTISE_SLCT		0x001f	/* Selector bits	       */
+#define ADVERTISE_CSMA		0x0001	/* Only selector supported     */
+#define ADVERTISE_10HALF	0x0020	/* Try for 10mbps half-duplex  */
+#define ADVERTISE_1000XFULL	0x0020	/* Try for 1000BASE-X full-duplex */
+#define ADVERTISE_10FULL	0x0040	/* Try for 10mbps full-duplex  */
+#define ADVERTISE_1000XHALF	0x0040	/* Try for 1000BASE-X half-duplex */
+#define ADVERTISE_100HALF	0x0080	/* Try for 100mbps half-duplex */
+#define ADVERTISE_1000XPAUSE	0x0080	/* Try for 1000BASE-X pause    */
+#define ADVERTISE_100FULL	0x0100	/* Try for 100mbps full-duplex */
+#define ADVERTISE_1000XPSE_ASYM 0x0100	/* Try for 1000BASE-X asym pause */
+#define ADVERTISE_100BASE4	0x0200	/* Try for 100mbps 4k packets  */
+#define ADVERTISE_PAUSE_CAP	0x0400	/* Try for pause	       */
+#define ADVERTISE_PAUSE_ASYM	0x0800	/* Try for asymetric pause     */
+#define ADVERTISE_RESV		0x1000	/* Unused...		       */
+#define ADVERTISE_RFAULT	0x2000	/* Say we can detect faults    */
+#define ADVERTISE_LPACK		0x4000	/* Ack link partners response  */
+#define ADVERTISE_NPAGE		0x8000	/* Next page bit	       */
+
+#define ADVERTISE_FULL (ADVERTISE_100FULL | ADVERTISE_10FULL | \
+			ADVERTISE_CSMA)
+#define ADVERTISE_ALL (ADVERTISE_10HALF | ADVERTISE_10FULL | \
+			   ADVERTISE_100HALF | ADVERTISE_100FULL)
+
+/* 1000BASE-T Control register */
+#define ADVERTISE_1000FULL	0x0200	/* Advertise 1000BASE-T full duplex */
+#define ADVERTISE_1000HALF	0x0100	/* Advertise 1000BASE-T half duplex */
+
+
+#define PHY_AUTONEGOTIATE_TIMEOUT 5000
+
+/* 88E1011 PHY Status Register */
+#define MIIM_88E1xxx_PHY_STATUS		0x11
+#define MIIM_88E1xxx_PHYSTAT_SPEED	0xc000
+#define MIIM_88E1xxx_PHYSTAT_GBIT	0x8000
+#define MIIM_88E1xxx_PHYSTAT_100	0x4000
+#define MIIM_88E1xxx_PHYSTAT_DUPLEX	0x2000
+#define MIIM_88E1xxx_PHYSTAT_SPDDONE	0x0800
+#define MIIM_88E1xxx_PHYSTAT_LINK	0x0400
+
+#define MIIM_88E1xxx_PHY_SCR		0x10
+#define MIIM_88E1xxx_PHY_MDI_X_AUTO	0x0060
+
+
+/* Mask used to verify certain PHY features (or register contents)
+ * in the register above:
+ *  0x1000: 10Mbps full duplex support
+ *  0x0800: 10Mbps half duplex support
+ *  0x0008: Auto-negotiation support
+ */
+#define PHY_DETECT_MASK 0x1808
+
+
+namespace Genode {
+
+
+void Marvel_phy::init()
+{
+	phy_detection();
+
+	uint32_t phy_id = 0;
+	get_phy_id(&phy_id);
+	PDBG("The found phy has the id %08x", phy_id);
+
+	phy_reset();
+	m88e1310_config();
+	m88e1011s_startup();
+}
+
+
+void Marvel_phy::phy_read(const uint32_t regnum, uint16_t *val)
+{
+	_phyio.phy_read(_phyaddr, regnum, *val);
+}
+
+
+void Marvel_phy::phy_write(const uint32_t regnum, const uint16_t data)
+{
+	_phyio.phy_write(_phyaddr, regnum, data);
+}
+
+
+void Marvel_phy::phy_detection()
+{
+	if (_phyaddr != -1) {
+		uint16_t phyreg = 0xEEEE;
+		phy_read(MII_BMSR, &phyreg);
+		if ((phyreg != 0xFFFF) &&
+			((phyreg & PHY_DETECT_MASK) == PHY_DETECT_MASK)) {
+			/* Found a valid PHY address */
+			PDBG("Default phy address %d is valid\n", _phyaddr);
+			return;
+		} else {
+			PDBG("PHY address is not setup correctly %d\n", _phyaddr);
+			_phyaddr = -1;
+		}
+	}
+
+	PDBG("detecting phy address\n");
+	if (_phyaddr == -1) {
+		/* detect the PHY address */
+		for (int i = 31; i >= 0; i--) {
+			uint16_t phyreg = 0xEEEE;
+			_phyaddr = i;
+			phy_read(MII_BMSR, &phyreg);
+			if ((phyreg != 0xFFFF) &&
+				((phyreg & PHY_DETECT_MASK) == PHY_DETECT_MASK)) {
+				/* Found a valid PHY address */
+				PDBG("Found valid phy address, %d\n", i);
+				return;
+			}
+		}
+	}
+	PDBG("PHY is not detected\n");
+	_phyaddr = -1;
+}
+
+/**
+ * get_phy_id - reads the specified addr for its ID.
+ * @bus: the target MII bus
+ * @addr: PHY address on the MII bus
+ * @phy_id: where to store the ID retrieved.
+ *
+ * Description: Reads the ID registers of the PHY at @addr on the
+ *   @bus, stores it in @phy_id and returns zero on success.
+ */
+void Marvel_phy::get_phy_id(uint32_t *phy_id)
+{
+	uint16_t phy_reg = 0;
+
+	/* Grab the bits from PHYIR1, and put them
+	 * in the upper half */
+	phy_read(MII_PHYSID1, &phy_reg);
+	*phy_id = (phy_reg & 0xffff) << 16;
+
+	/* Grab the bits from PHYIR2, and put them in the lower half */
+	phy_read(MII_PHYSID2, &phy_reg);
+	*phy_id |= (phy_reg & 0xffff);
+}
+
+
+void Marvel_phy::m88e1310_config()
+{
+	uint16_t reg = 0;
+
+	/* LED link and activity */
+	phy_write(MIIM_88E1310_PHY_PAGE, 0x0003);
+	phy_read(MIIM_88E1310_PHY_LED_CTRL, &reg);
+	reg = (reg & ~0xf) | 0x1;
+	phy_write(MIIM_88E1310_PHY_LED_CTRL, reg);
+
+	/* Set LED2/INT to INT mode, low active */
+	phy_write(MIIM_88E1310_PHY_PAGE, 0x0003);
+	phy_read(MIIM_88E1310_PHY_IRQ_EN, &reg);
+	reg = (reg & 0x77ff) | 0x0880;
+	phy_write(MIIM_88E1310_PHY_IRQ_EN, reg);
+
+	/* Set RGMII delay */
+	phy_write(MIIM_88E1310_PHY_PAGE, 0x0002);
+	phy_read(MIIM_88E1310_PHY_RGMII_CTRL, &reg);
+	reg |= 0x0030;
+	phy_write(MIIM_88E1310_PHY_RGMII_CTRL, reg);
+
+	/* Ensure to return to page 0 */
+	phy_write(MIIM_88E1310_PHY_PAGE, 0x0000);
+
+	genphy_config_aneg();
+	phy_reset();
+}
+
+
+/**
+ * genphy_config_aneg - restart auto-negotiation or write BMCR
+ * @phydev: target phy_device struct
+ *
+ * Description: If auto-negotiation is enabled, we configure the
+ *   advertising, and then restart auto-negotiation.  If it is not
+ *   enabled, then we write the BMCR.
+ */
+int Marvel_phy::genphy_config_aneg()
+{
+	int result = genphy_config_advert();
+
+	if (result < 0) /* error */
+		return result;
+
+	if (result == 0) {
+		PDBG("Config not changed");
+		/* Advertisment hasn't changed, but maybe aneg was never on to
+		 * begin with?  Or maybe phy was isolated? */
+		uint16_t ctl = 0;
+		phy_read(MII_BMCR, &ctl);
+
+		if (!(ctl & BMCR_ANENABLE) || (ctl & BMCR_ISOLATE))
+			result = 1; /* do restart aneg */
+	} else {
+		PDBG("Config changed");
+	}
+
+	/* Only restart aneg if we are advertising something different
+	 * than we were before.	 */
+	if (result > 0)
+		result = genphy_restart_aneg();
+
+	return result;
+}
+
+
+/**
+ * genphy_config_advert - sanitize and advertise auto-negotation parameters
+ * @phydev: target phy_device struct
+ *
+ * Description: Writes MII_ADVERTISE with the appropriate values,
+ *   after sanitizing the values to make sure we only advertise
+ *   what is supported.  Returns < 0 on error, 0 if the PHY's advertisement
+ *   hasn't changed, and > 0 if it has changed.
+ */
+int Marvel_phy::genphy_config_advert()
+{
+	uint16_t adv = 0;
+	int changed = 0;
+
+	/* Setup standard advertisement */
+	phy_read(MII_ADVERTISE, &adv);
+
+	uint16_t oldadv = adv;
+
+	adv &= ~(ADVERTISE_ALL | ADVERTISE_100BASE4 | ADVERTISE_PAUSE_CAP | ADVERTISE_PAUSE_ASYM);
+	adv |= ADVERTISE_10HALF;
+	adv |= ADVERTISE_10FULL;
+	adv |= ADVERTISE_100HALF;
+	adv |= ADVERTISE_100FULL;
+	adv |= ADVERTISE_PAUSE_CAP;
+	adv |= ADVERTISE_PAUSE_ASYM;
+
+	if (adv != oldadv) {
+		phy_write(MII_ADVERTISE, adv);
+		changed = 1;
+	}
+
+	/* Configure gigabit if it's supported */
+	phy_read(MII_CTRL1000, &adv);
+
+	oldadv = adv;
+
+
+	adv &= ~(ADVERTISE_1000FULL | ADVERTISE_1000HALF);
+	adv |= ADVERTISE_1000HALF;
+	adv |= ADVERTISE_1000FULL;
+
+	if (adv != oldadv) {
+		phy_write(MII_CTRL1000, adv);
+		changed = 1;
+	}
+
+	return changed;
+}
+
+/**
+ * genphy_restart_aneg - Enable and Restart Autonegotiation
+ * @phydev: target phy_device struct
+ */
+int Marvel_phy::genphy_restart_aneg()
+{
+	uint16_t ctl = 0;
+	phy_read(MII_BMCR, &ctl);
+
+	ctl |= (BMCR_ANENABLE | BMCR_ANRESTART);
+
+	/* Don't isolate the PHY if we're negotiating */
+	ctl &= ~(BMCR_ISOLATE);
+
+	phy_write(MII_BMCR, ctl);
+
+	return 0;
+}
+
+
+int Marvel_phy::phy_reset()
+{
+	uint16_t reg = 0;
+	int timeout = 500;
+
+	phy_read(MII_BMCR, &reg);
+
+	reg |= BMCR_RESET;
+
+	phy_write(MII_BMCR, reg);
+
+	/*
+	 * Poll the control register for the reset bit to go to 0 (it is
+	 * auto-clearing).  This should happen within 0.5 seconds per the
+	 * IEEE spec.
+	 */
+	while ((reg & BMCR_RESET) && timeout--) {
+		phy_read(MII_BMCR, &reg);
+		_timer.msleep(1);
+	}
+
+	if (reg & BMCR_RESET) {
+		PWRN("PHY reset timed out\n");
+		throw Phy_timeout_after_reset();
+	}
+
+	return 0;
+}
+
+
+int Marvel_phy::m88e1011s_startup()
+{
+	genphy_update_link();
+	m88e1xxx_parse_status();
+
+	return 0;
+}
+
+
+
+/**
+ * genphy_update_link - update link status in @phydev
+ * @phydev: target phy_device struct
+ *
+ * Description: Update the value in phydev->link to reflect the
+ *   current link value.  In order to do this, we need to read
+ *   the status register twice, keeping the second value.
+ */
+int Marvel_phy::genphy_update_link()
+{
+	uint16_t mii_reg = 0;
+
+	/*
+	 * Wait if the link is up, and autonegotiation is in progress
+	 * (ie - we're capable and it's not done)
+	 */
+	phy_read(MII_BMSR, &mii_reg);
+
+	/*
+	 * If we already saw the link up, and it hasn't gone down, then
+	 * we don't need to wait for autoneg again
+	 */
+	if (_link_up && mii_reg & BMSR_LSTATUS)
+		return 0;
+
+	if ((mii_reg & BMSR_ANEGCAPABLE) && !(mii_reg & BMSR_ANEGCOMPLETE)) {
+		int i = 0;
+
+		Genode::printf("Waiting for PHY auto negotiation to complete");
+		while (!(mii_reg & BMSR_ANEGCOMPLETE)) {
+			/*
+			 * Timeout reached ?
+			 */
+			if (i > PHY_AUTONEGOTIATE_TIMEOUT) {
+				PWRN(" TIMEOUT !\n");
+				_link_up = false;
+				return 0;
+			}
+
+			if ((i++ % 500) == 0)
+				Genode::printf(".");
+			_timer.msleep(1);
+
+			phy_read(MII_BMSR, &mii_reg);
+		}
+		Genode::printf(" done\n");
+		_link_up = true;
+	} else {
+		/* Read the link a second time to clear the latched state */
+		phy_read(MII_BMSR, &mii_reg);
+
+		if (mii_reg & BMSR_LSTATUS)
+			_link_up = true;
+		else
+			_link_up = false;
+	}
+
+	return 0;
+}
+
+
+/* Parse the 88E1011's status register for speed and duplex
+ * information
+ */
+int Marvel_phy::m88e1xxx_parse_status()
+{
+	unsigned int speed;
+	uint16_t mii_reg = 0;
+
+	phy_read(MIIM_88E1xxx_PHY_STATUS, &mii_reg);
+
+	if ((mii_reg & MIIM_88E1xxx_PHYSTAT_LINK) &&
+		!(mii_reg & MIIM_88E1xxx_PHYSTAT_SPDDONE)) {
+		int i = 0;
+
+		PDBG("Waiting for PHY realtime link");
+		while (!(mii_reg & MIIM_88E1xxx_PHYSTAT_SPDDONE)) {
+			/* Timeout reached ? */
+			if (i > PHY_AUTONEGOTIATE_TIMEOUT) {
+				PWRN(" TIMEOUT !");
+				_link_up = false;
+				break;
+			}
+
+			if ((i++ % 1000) == 0)
+				Genode::printf(".");
+			_timer.msleep(1);
+			phy_read(MIIM_88E1xxx_PHY_STATUS, &mii_reg);
+		}
+		PINF(" done");
+		_timer.msleep(500);
+	} else {
+		if (mii_reg & MIIM_88E1xxx_PHYSTAT_LINK)
+			_link_up = true;
+		else
+			_link_up = false;
+	}
+
+	// TODO change emac configuration if half duplex
+//				if (mii_reg & MIIM_88E1xxx_PHYSTAT_DUPLEX)
+//					phydev->duplex = DUPLEX_FULL;
+//				else
+//					phydev->duplex = DUPLEX_HALF;
+
+	speed = mii_reg & MIIM_88E1xxx_PHYSTAT_SPEED;
+
+	switch (speed) {
+	case MIIM_88E1xxx_PHYSTAT_GBIT:
+		_eth_speed = SPEED_1000;
+		break;
+	case MIIM_88E1xxx_PHYSTAT_100:
+		_eth_speed = SPEED_100;
+		break;
+	default:
+		_eth_speed = SPEED_10;
+		break;
+	}
+
+	return 0;
+}
+
+}

--- a/repos/os/src/drivers/nic/gem/marvell_phy.h
+++ b/repos/os/src/drivers/nic/gem/marvell_phy.h
@@ -1,0 +1,81 @@
+/*
+ * \brief  Phy driver for Marvell chips
+ * \author Timo Wischer
+ * \date   2015-05-11
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__MARVELL_PHY_H_
+#define _INCLUDE__DRIVERS__NIC__MARVELL_PHY_H_
+
+/* Genode includes */
+#include <os/attached_mmio.h>
+#include <nic_session/nic_session.h>
+#include <nic/driver.h>
+#include <timer_session/connection.h>
+
+#include "phyio.h"
+
+
+namespace Genode
+{
+
+	enum Eth_speed {
+		UNDEFINED,
+		SPEED_10 = 10,
+		SPEED_100 = 100,
+		SPEED_1000 = 1000
+	};
+
+
+	class Marvel_phy
+	{
+		public:
+			class Phy_timeout_after_reset : public Genode::Exception {};
+
+
+		private:
+			Timer::Connection _timer;
+
+			Phyio& _phyio;
+			uint16_t _phyaddr;
+			bool _link_up;
+			Eth_speed _eth_speed;
+
+			void phy_read(const uint32_t regnum, uint16_t *val);
+			void phy_write(const uint32_t regnum, const uint16_t data);
+			void phy_detection();
+			void get_phy_id(uint32_t *phy_id);
+			void m88e1310_config();
+			int genphy_config_aneg();
+			int genphy_config_advert();
+			int genphy_restart_aneg();
+			int phy_reset();
+			int m88e1011s_startup();
+			int genphy_update_link();
+			int m88e1xxx_parse_status();
+
+
+		public:
+			Marvel_phy(Phyio& phyio) :
+				_phyio(phyio),
+				_phyaddr(0),
+				_link_up(false),
+				_eth_speed(UNDEFINED)
+			{ }
+
+			void init();
+
+			Eth_speed eth_speed() { return _eth_speed; }
+
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__NIC__XILINX_EMACPS_BASE_H_ */
+

--- a/repos/os/src/drivers/nic/gem/phyio.h
+++ b/repos/os/src/drivers/nic/gem/phyio.h
@@ -1,0 +1,31 @@
+/*
+ * \brief  Phy driver for Marvell chips
+ * \author Timo Wischer
+ * \date   2015-05-11
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__PHYIO_H_
+#define _INCLUDE__DRIVERS__NIC__PHYIO_H_
+
+
+namespace Genode
+{
+	class Phyio
+	{
+		public:
+			virtual void phy_write(const uint8_t phyaddr, const uint8_t regnum, const uint16_t data) = 0;
+			virtual void phy_read(const uint8_t phyaddr, const uint8_t regnum, uint16_t &data) = 0;
+
+
+	};
+}
+
+#endif /* _INCLUDE__DRIVERS__NIC__PHYIO_H_ */
+

--- a/repos/os/src/drivers/nic/gem/rx_buffer_descriptor.h
+++ b/repos/os/src/drivers/nic/gem/rx_buffer_descriptor.h
@@ -1,0 +1,134 @@
+/*
+ * \brief  Base EMAC driver for the Xilinx EMAC PS used on Zynq devices
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__RX_BUFFER_DESCRIPTOR_H_
+#define _INCLUDE__DRIVERS__NIC__RX_BUFFER_DESCRIPTOR_H_
+
+#include "buffer_descriptor.h"
+
+using namespace Genode;
+
+
+class Rx_buffer_descriptor : public Buffer_descriptor
+{
+	private:
+		struct Addr : Register<0x00, 32> {
+			struct Addr31to2 : Bitfield<2, 28> {};
+			struct Wrap : Bitfield<1, 1> {};
+			struct Package_available : Bitfield<0, 1> {};
+		};
+		struct Status : Register<0x04, 32> {
+			struct Length : Bitfield<0, 13> {};
+			struct Start_of_frame : Bitfield<14, 1> {};
+			struct End_of_frame : Bitfield<15, 1> {};
+		};
+
+		enum { BUFFER_COUNT = 16 };
+
+
+		/**
+		 * @brief _set_buffer_processed resets the available flag
+		 * So the DMA controller can use this buffer for an received package.
+		 * The buffer index will be incremented, too.
+		 * So the right sequenz of packages will be keeped.
+		 */
+		void _set_package_processed()
+		{
+			/* reset package available for new package */
+			_current_descriptor().addr &= ~Addr::Package_available::bits(1);
+			/* use next buffer descriptor for next package */
+			_increment_descriptor_index();
+		}
+
+
+	public:
+		Rx_buffer_descriptor() : Buffer_descriptor(BUFFER_COUNT)
+		{
+			/*
+			 * mark the last buffer descriptor
+			 * so the dma will start at the beginning again
+			 */
+			_descriptors[BUFFER_COUNT-1].addr |= Addr::Wrap::bits(1);
+		}
+
+
+		bool package_available()
+		{
+			for (unsigned int i=0; i<BUFFER_COUNT; i++) {
+				const bool available = Addr::Package_available::get(_current_descriptor().addr);
+				if (available) {
+					return true;
+				}
+
+				_increment_descriptor_index();
+			}
+
+			return false;
+		}
+
+
+		size_t package_length()
+		{
+			if (!package_available())
+				return 0;
+
+			return Status::Length::get(_current_descriptor().status);
+		}
+
+
+		size_t get_package(char* const package, const size_t max_length)
+		{
+			if (!package_available())
+				return 0;
+
+			const Status::access_t status = _current_descriptor().status;
+			if (!Status::Start_of_frame::get(status) || !Status::End_of_frame::get(status)) {
+				PWRN("Package splitted over more than one descriptor. Package ignored!");
+
+				_set_package_processed();
+				return 0;
+			}
+
+			const size_t length = Status::Length::get(status);
+			if (length > max_length) {
+				PWRN("Buffer for received package to small. Package ignored!");
+
+				_set_package_processed();
+				return 0;
+			}
+
+			const char* const src_buffer = _current_buffer();
+			memcpy(package, src_buffer, length);
+
+			_set_package_processed();
+
+
+			return length;
+		}
+
+		void show_mem_diffs()
+		{
+			static unsigned int old_data[0x1F];
+
+			PDBG("Rx buffer:");
+			const unsigned int* const cur_data = local_addr<unsigned int>();
+			for (unsigned i=0; i<sizeof(old_data)/sizeof(old_data[0]); i++) {
+				if (cur_data[i] != old_data[i]) {
+					PDBG("%04x: %08x -> %08x", i*4, old_data[i], cur_data[i]);
+				}
+			}
+			memcpy(old_data, cur_data, sizeof(old_data));
+		}
+};
+
+#endif /* _INCLUDE__DRIVERS__NIC__RX_BUFFER_DESCRIPTOR_H_ */

--- a/repos/os/src/drivers/nic/gem/system_control.h
+++ b/repos/os/src/drivers/nic/gem/system_control.h
@@ -1,0 +1,151 @@
+/*
+ * \brief  Base EMAC driver for the Xilinx EMAC PS used on Zynq devices
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__SYSTEM_CONTROL_H_
+#define _INCLUDE__DRIVERS__NIC__SYSTEM_CONTROL_H_
+
+/* Genode includes */
+#include <os/attached_mmio.h>
+#include <timer_session/connection.h>
+
+#include <drivers/board_base.h>
+
+
+using namespace Genode;
+
+
+class System_control : private Genode::Attached_mmio
+{
+	private:
+		struct Lock : Register<0x4, 32> {
+			enum { MAGIC = 0x767B };
+		};
+		struct Unlock : Register<0x8, 32> {
+			enum { MAGIC = 0xDF0D };
+		};
+		struct Gem0_rclk_ctrl : Register<0x138, 32> { };
+		struct Gem0_clk_ctrl : Register<0x140, 32> { };
+
+		struct Mio_pin_16 : Register<0x740, 32> {
+			struct Tri_state_enable  : Bitfield<0, 1> {};
+			struct Level_0_mux  : Bitfield<1, 1> {
+				enum { ETH0 = 0b1 };
+			};
+			struct Fast_cmos_edge  : Bitfield<8, 1> {};
+			struct IO_type  : Bitfield<9, 3> {
+				enum { LVCMOS18 = 0b001 };
+			};
+
+			static access_t FAST_LVCMOS18_ETH0() {
+				return Fast_cmos_edge::bits(1) |
+					IO_type::bits(IO_type::LVCMOS18) |
+					Level_0_mux::bits(Level_0_mux::ETH0);
+			}
+
+			static access_t FAST_LVCMOS18_ETH0_TRISTATE() {
+				return FAST_LVCMOS18_ETH0() |
+					Tri_state_enable::bits(1);
+			}
+		};
+		struct Mio_pin_17 : Register<0x744, 32> { };
+		struct Mio_pin_18 : Register<0x748, 32> { };
+		struct Mio_pin_19 : Register<0x74C, 32> { };
+		struct Mio_pin_20 : Register<0x750, 32> { };
+		struct Mio_pin_21 : Register<0x754, 32> { };
+		struct Mio_pin_22 : Register<0x758, 32> { };
+		struct Mio_pin_23 : Register<0x75C, 32> { };
+		struct Mio_pin_24 : Register<0x760, 32> { };
+		struct Mio_pin_25 : Register<0x764, 32> { };
+		struct Mio_pin_26 : Register<0x768, 32> { };
+		struct Mio_pin_27 : Register<0x76C, 32> { };
+
+		struct Mio_pin_52 : Register<0x7D0, 32> {
+			struct Level_3_mux  : Bitfield<5, 3> {
+				enum { MDIO0 = 0b100 };
+			};
+
+			static access_t LVCMOS18_MDIO0() {
+				return Mio_pin_16::IO_type::bits(Mio_pin_16::IO_type::LVCMOS18) |
+					Level_3_mux::bits(Level_3_mux::MDIO0);
+			}
+		};
+		struct Mio_pin_53 : Register<0x7D4, 32> { };
+
+		struct Gpio_b_ctrl : Register<0xB00, 32> {
+			struct Vref_enable  : Bitfield<0, 1> {};
+		};
+
+
+		class Lock_guard
+		{
+			private:
+				System_control& _sys_ctrl;
+
+				void _unlock() { _sys_ctrl.write<Unlock>(Unlock::MAGIC); }
+				void _lock() { _sys_ctrl.write<Lock>(Lock::MAGIC); }
+
+			public:
+				Lock_guard(System_control& sys_ctrl) : _sys_ctrl(sys_ctrl)
+				{
+					_unlock();
+				}
+
+				~Lock_guard()
+				{
+					_lock();
+				}
+		};
+
+		unsigned int old_data[0x300];
+
+	public:
+		System_control() :
+			Attached_mmio(Board_base::MMIO_1_BASE, 0xB80)
+		{
+			Lock_guard lock(*this);
+
+			write<Mio_pin_16>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+			write<Mio_pin_17>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+			write<Mio_pin_18>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+			write<Mio_pin_19>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+			write<Mio_pin_20>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+			write<Mio_pin_21>(Mio_pin_16::FAST_LVCMOS18_ETH0());
+
+			write<Mio_pin_22>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+			write<Mio_pin_23>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+			write<Mio_pin_24>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+			write<Mio_pin_25>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+			write<Mio_pin_26>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+			write<Mio_pin_27>(Mio_pin_16::FAST_LVCMOS18_ETH0_TRISTATE());
+
+			write<Mio_pin_52>(Mio_pin_52::LVCMOS18_MDIO0());
+			write<Mio_pin_53>(Mio_pin_52::LVCMOS18_MDIO0());
+
+			// TODO possibly not needed because uboot do not enable this register
+			/* enable internel VRef */
+			write<Gpio_b_ctrl>(Gpio_b_ctrl::Vref_enable::bits(1));
+		}
+
+		void set_clk(uint32_t clk, uint32_t rclk)
+		{
+			Lock_guard lock(*this);
+
+			write<Gem0_clk_ctrl>(clk);
+			write<Gem0_rclk_ctrl>(rclk);
+
+			static Timer::Connection timer;
+			timer.msleep(100);
+		}
+};
+
+#endif /* _INCLUDE__DRIVERS__NIC__SYSTEM_CONTROL_H_ */

--- a/repos/os/src/drivers/nic/gem/target.mk
+++ b/repos/os/src/drivers/nic/gem/target.mk
@@ -1,0 +1,5 @@
+REQUIRES = cadence_gem
+TARGET   = nic_drv
+SRC_CC   = main.cc marvell_phy.cc
+LIBS     = base
+INC_DIR += $(PRG_DIR)

--- a/repos/os/src/drivers/nic/gem/tx_buffer_descriptor.h
+++ b/repos/os/src/drivers/nic/gem/tx_buffer_descriptor.h
@@ -1,0 +1,82 @@
+/*
+ * \brief  Base EMAC driver for the Xilinx EMAC PS used on Zynq devices
+ * \author Timo Wischer
+ * \date   2015-03-10
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _INCLUDE__DRIVERS__NIC__TX_BUFFER_DESCRIPTOR_H_
+#define _INCLUDE__DRIVERS__NIC__TX_BUFFER_DESCRIPTOR_H_
+
+#include <timer_session/connection.h>
+
+#include "buffer_descriptor.h"
+
+using namespace Genode;
+
+
+class Tx_buffer_descriptor : public Buffer_descriptor
+{
+	private:
+		enum { BUFFER_COUNT = 2 };
+
+		struct Addr : Register<0x00, 32> {};
+		struct Status : Register<0x04, 32> {
+			struct Length  : Bitfield<0, 14> {};
+			struct Last_buffer  : Bitfield<15, 1> {};
+			struct Wrap  : Bitfield<30, 1> {};
+			struct Used  : Bitfield<31, 1> {};
+		};
+
+		class Package_send_timeout : public Genode::Exception {};
+
+
+	public:
+		Tx_buffer_descriptor() : Buffer_descriptor(BUFFER_COUNT)
+		{
+			for (unsigned int i=0; i<BUFFER_COUNT; i++) {
+				_descriptors[i].status = Status::Used::bits(1) | Status::Last_buffer::bits(1);
+			}
+			_descriptors[BUFFER_COUNT-1].status |= Status::Wrap::bits(1);
+		}
+
+
+		void add_to_queue(const char* const packet, const size_t size)
+		{
+			if (size > MAX_PACKAGE_SIZE) {
+				PWRN("Ethernet package to big. Not sent!");
+				return;
+			}
+
+			/* wait until the used bit is set (timeout after 200ms) */
+			uint32_t timeout = 200;
+			while ( !Status::Used::get(_current_descriptor().status) ) {
+				if (timeout <= 0) {
+					throw Package_send_timeout();
+				}
+				timeout--;
+
+				static Timer::Connection timer;
+				timer.msleep(1);
+			}
+
+
+			memcpy(_current_buffer(), packet, size);
+
+			_current_descriptor().status &=  Status::Length::clear_mask();
+			_current_descriptor().status |=  Status::Length::bits(size);
+
+			/* unset the unset bit */
+			_current_descriptor().status &=  Status::Used::clear_mask();
+
+			_increment_descriptor_index();
+		}
+};
+
+#endif /* _INCLUDE__DRIVERS__NIC__TX_BUFFER_DESCRIPTOR_H_ */

--- a/repos/os/src/drivers/timer/hw/zynq/platform_timer_base.h
+++ b/repos/os/src/drivers/timer/hw/zynq/platform_timer_base.h
@@ -1,0 +1,47 @@
+/*
+ * \brief  Platform-timer base specific for base-hw and zynq
+ * \author Johannes Schlatow
+ * \date   2015-03-05
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _OS__SRC__DRIVERS__TIMER__HW__ZYNQ__PLATFORM_TIMER_BASE_H_
+#define _OS__SRC__DRIVERS__TIMER__HW__ZYNQ__PLATFORM_TIMER_BASE_H_
+
+/* Genode includes */
+#include <io_mem_session/connection.h>
+#include <util/mmio.h>
+#include <drivers/timer/ttc_base.h>
+#include <drivers/board_base.h>
+
+/**
+ * Platform-timer base specific for base-hw and zynq
+ * (see Xilinx ug585 "Zynq 7000 Technical Reference Manual")
+ */
+class Platform_timer_base :
+	public Genode::Io_mem_connection,
+	public Genode::Ttc_base<0, Genode::Board_base::CPU_1x_CLOCK>
+{
+	public:
+
+		enum { IRQ = Genode::Board_base::TTC0_IRQ_0};
+
+		/**
+		 * Constructor
+		 */
+		Platform_timer_base() :
+			Io_mem_connection(Genode::Board_base::TTC0_MMIO_BASE,
+			                  Genode::Board_base::TTC0_MMIO_SIZE),
+
+			Ttc_base((Genode::addr_t)Genode::env()->rm_session()->attach(dataspace()))
+		{ }
+};
+
+#endif /* _OS__SRC__DRIVERS__TIMER__HW__ZYNQ__PLATFORM_TIMER_BASE_H_ */
+

--- a/repos/os/src/drivers/vdma/zynq/driver.h
+++ b/repos/os/src/drivers/vdma/zynq/driver.h
@@ -1,0 +1,105 @@
+/*
+ * \brief  VDMA Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _DRIVER_H_
+#define _DRIVER_H_
+
+#include <io_mem_session/connection.h>
+#include <timer_session/connection.h>
+#include <util/mmio.h>
+#include <vector>
+#include <new>
+#include <platform/zynq/drivers/board_base.h>
+#include "vdma.h"
+
+namespace Vdma {
+	using namespace Genode;
+	class Driver;
+}
+
+class Vdma::Driver
+{
+    private:
+
+        std::vector<Zynq_Vdma*> _vdma_bank;
+
+        Driver(std::vector<Genode::addr_t> addr)
+        {
+            for (unsigned i = 0; i < addr.size(); i++)
+            {
+                _vdma_bank.push_back(new Zynq_Vdma(addr[i], Genode::Board_base::VDMA_MMIO_SIZE));
+            }
+        }
+
+        ~Driver()
+        {
+            for (std::vector<Zynq_Vdma*>::iterator it = _vdma_bank.begin() ; it != _vdma_bank.end(); ++it)
+            {
+                delete (*it);
+            }
+            _vdma_bank.clear();
+        }
+
+	public:
+
+        static Driver& factory(std::vector<Genode::addr_t> addr);
+
+        bool setConfig(unsigned vdma, Genode::uint32_t data, bool isMM2S)
+        {
+            Zynq_Vdma *vdma_reg = _vdma_bank[vdma];
+            if (isMM2S) vdma_reg->write<Zynq_Vdma::MM2S_VDMACR>(data);
+            else vdma_reg->write<Zynq_Vdma::S2MM_VDMACR>(data);
+            return true;
+        }
+
+        bool setStride(unsigned vdma, Genode::uint16_t data, bool isMM2S)
+        {
+            Zynq_Vdma *vdma_reg = _vdma_bank[vdma];
+            if (isMM2S) vdma_reg->write<Zynq_Vdma::MM2S_FRMDLY_STRIDE>(data);
+            else vdma_reg->write<Zynq_Vdma::S2MM_FRMDLY_STRIDE>(data);
+            return true;
+        }
+
+        bool setWidth(unsigned vdma, Genode::uint16_t data, bool isMM2S)
+        {
+            Zynq_Vdma *vdma_reg = _vdma_bank[vdma];
+            if (isMM2S) vdma_reg->write<Zynq_Vdma::MM2S_HSIZE>(data);
+            else vdma_reg->write<Zynq_Vdma::S2MM_HSIZE>(data);
+            return true;
+        }
+
+        bool setHeight(unsigned vdma, Genode::uint16_t data, bool isMM2S)
+        {
+            Zynq_Vdma *vdma_reg = _vdma_bank[vdma];
+            if (isMM2S) vdma_reg->write<Zynq_Vdma::MM2S_VSIZE>(data);
+            else vdma_reg->write<Zynq_Vdma::S2MM_VSIZE>(data);
+            return true;
+        }
+
+
+        bool setAddr(unsigned vdma, Genode::uint32_t data, bool isMM2S)
+        {
+            Zynq_Vdma *vdma_reg = _vdma_bank[vdma];
+            if (isMM2S) vdma_reg->write<Zynq_Vdma::MM2S_START_ADDRESS>(data);
+            else vdma_reg->write<Zynq_Vdma::S2MM_START_ADDRESS>(data);
+            return true;
+        }
+};
+
+Vdma::Driver& Vdma::Driver::factory(std::vector<Genode::addr_t> addr)
+{
+    static Vdma::Driver driver(addr);
+    return driver;
+}
+
+#endif /* _DRIVER_H_ */

--- a/repos/os/src/drivers/vdma/zynq/main.cc
+++ b/repos/os/src/drivers/vdma/zynq/main.cc
@@ -1,0 +1,147 @@
+/*
+ * \brief  VDMA Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#include <vdma_session/zynq/vdma_session.h>
+#include <cap_session/connection.h>
+#include <dataspace/client.h>
+#include <base/printf.h>
+#include <base/sleep.h>
+#include <root/component.h>
+#include <os/static_root.h>
+#include <os/config.h>
+#include <vector>
+#include "driver.h"
+
+namespace Vdma {
+	using namespace Genode;
+	class Session_component;
+	class Root;
+};
+
+class Vdma::Session_component : public Genode::Rpc_object<Vdma::Session>
+{
+	private:
+
+		Driver &_driver;
+        unsigned _number;
+
+	public:
+
+        Session_component(Driver &driver, unsigned vdma_number) : _driver(driver), _number(vdma_number) {}
+
+        virtual bool setConfig(Genode::uint32_t data, bool isMM2S)
+        {
+            return _driver.setConfig(_number, data, isMM2S);
+        }
+
+        virtual bool setStride(Genode::uint16_t data, bool isMM2S)
+        {
+            return _driver.setStride(_number, data, isMM2S);
+        }
+
+        virtual bool setWidth(Genode::uint16_t data, bool isMM2S)
+        {
+            return _driver.setWidth(_number, data, isMM2S);
+        }
+
+        virtual bool setHeight(Genode::uint16_t data, bool isMM2S)
+        {
+            return _driver.setHeight(_number, data, isMM2S);
+        }
+
+        virtual bool setAddr(Genode::uint32_t data, bool isMM2S)
+        {
+            return _driver.setAddr(_number, data, isMM2S);
+        }
+};
+
+class Vdma::Root : public Genode::Root_component<Vdma::Session_component>
+{
+	private:
+
+		Driver &_driver;
+
+	protected:
+
+		Session_component *_create_session(const char *args)
+		{
+            unsigned number = Genode::Arg_string::find_arg(args, "vdma").ulong_value(0);
+            Genode::size_t ram_quota = Genode::Arg_string::find_arg(args, "ram_quota").ulong_value(0);
+
+            if (ram_quota < sizeof(Session_component)) {
+                PWRN("Insufficient dontated ram_quota (%zd bytes), require %zd bytes",
+                     ram_quota, sizeof(Session_component));
+                throw Genode::Root::Quota_exceeded();
+            }
+
+            return new (md_alloc()) Session_component(_driver, number);
+		}
+
+	public:
+
+		Root(Genode::Rpc_entrypoint *session_ep,
+		     Genode::Allocator *md_alloc, Driver &driver)
+        : Genode::Root_component<Vdma::Session_component>(session_ep, md_alloc),
+		  _driver(driver) { }
+};
+
+int main(int, char **)
+{
+    using namespace Vdma;
+
+    PINF("Zynq VDMA driver");
+
+    /*
+     * Read config
+     */
+    std::vector<Genode::addr_t> addr;
+
+    try {
+        Genode::Xml_node vdma_node = Genode::config()->xml_node().sub_node("vdma");
+
+        for (unsigned i = 0; ;i++, vdma_node = vdma_node.next("vdma"))
+        {
+            addr.push_back(0);
+            vdma_node.attribute("addr").value(&addr[i]);
+            PINF("VDMA with mio address 0x%x added.", (unsigned int)addr[i]);
+
+            if (vdma_node.is_last("vdma")) break;
+        }
+    }
+    catch (Genode::Xml_node::Nonexistent_sub_node) {
+        PWRN("No VDMA config");
+    }
+
+    /*
+     * Create Driver
+     */
+    Driver &driver = Driver::factory(addr);
+    addr.clear();
+
+	/*
+	 * Initialize server entry point
+	 */
+    enum { STACK_SIZE = 4096 };
+	static Cap_connection cap;
+	Sliced_heap sliced_heap(env()->ram_session(), env()->rm_session());
+    static Rpc_entrypoint ep(&cap, STACK_SIZE, "vdma_ep");
+    static Vdma::Root vdma_root(&ep, &sliced_heap, driver);
+
+	/*
+	 * Announce service
+     */
+    env()->parent()->announce(ep.manage(&vdma_root));
+
+	Genode::sleep_forever();
+	return 0;
+}

--- a/repos/os/src/drivers/vdma/zynq/target.mk
+++ b/repos/os/src/drivers/vdma/zynq/target.mk
@@ -1,0 +1,12 @@
+# \brief  VDMA specific for zynq systems
+# \author Mark Albers
+# \date   2015-04-13
+
+TARGET   = zynq_vdma_drv
+
+SRC_CC   = main.cc
+LIBS     = base config libc libm stdcxx
+INC_DIR += $(PRG_DIR)
+
+vpath main.cc $(PRG_DIR)
+

--- a/repos/os/src/drivers/vdma/zynq/vdma.h
+++ b/repos/os/src/drivers/vdma/zynq/vdma.h
@@ -1,0 +1,148 @@
+/*
+ * \brief  VDMA Driver for Zynq
+ * \author Mark Albers
+ * \date   2015-04-13
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _VDMA_H_
+#define _VDMA_H_
+
+#include <os/attached_io_mem_dataspace.h>
+#include <util/mmio.h>
+
+namespace Vdma {
+	using namespace Genode;
+    class Zynq_Vdma;
+}
+
+struct Vdma::Zynq_Vdma : Attached_io_mem_dataspace, Mmio
+{
+    Zynq_Vdma(Genode::addr_t const mmio_base, Genode::size_t const mmio_size) :
+		Genode::Attached_io_mem_dataspace(mmio_base, mmio_size),
+	  	Genode::Mmio((Genode::addr_t)local_addr<void>())
+    { }
+
+    ~Zynq_Vdma()
+    { }
+
+	/*
+	 * Registers
+	 */
+
+    struct MM2S_VDMACR : Register<0x00, 32>
+    {
+        struct Repeat_En : Bitfield<15,1> {};
+        struct Err_IrqEn : Bitfield<14,1> {};
+        struct RdPntrNum : Bitfield<8,4> {};
+        struct GenlockSrc : Bitfield<7,1> {};
+        struct GenlockEn : Bitfield<3,1> {};
+        struct Reset : Bitfield<2,1> {};
+        struct Circular_Park : Bitfield<1,1> {};
+        struct RS : Bitfield<0,1> {};
+    };
+
+    struct MM2S_VDMASR : Register<0x04, 32>
+    {
+        struct Err_Irq : Bitfield<14,1> {};
+        struct SOFEarlyErr : Bitfield<7,1> {};
+        struct VDMADecErr : Bitfield<6,1> {};
+        struct VDMASlvErr : Bitfield<5,1> {};
+        struct VDMAIntErr : Bitfield<4,1> {};
+        struct Halted : Bitfield<0,1> {};
+    };
+
+    struct MM2S_REG_INDEX : Register<0x14, 32>
+    {
+        struct MM2S_Reg_Index : Bitfield<0,1> {};
+    };
+
+    struct PARK_PTR_REG : Register<0x28, 32>
+    {
+        struct WrFrmStore : Bitfield<24,5> {};
+        struct RdFrmStore : Bitfield<16,5> {};
+        struct WrFrmPtrRef : Bitfield<8,5> {};
+        struct RdFrmPtrRef : Bitfield<0,5> {};
+    };
+
+    struct VDMA_VERSION : Register<0x2c, 32>
+    {
+        struct Major_Version : Bitfield<28,4> {};
+        struct Minor_Version : Bitfield<20,8> {};
+        struct Revision : Bitfield<16,4> {};
+        struct Xilinx_Internal : Bitfield<0,16> {};
+    };
+
+    struct S2MM_VDMACR : Register<0x30, 32>
+    {
+        struct Repeat_En : Bitfield<15,1> {};
+        struct Err_IrqEn : Bitfield<14,1> {};
+        struct WrPntrNum : Bitfield<8,4> {};
+        struct GenlockSrc : Bitfield<7,1> {};
+        struct GenlockEn : Bitfield<3,1> {};
+        struct Reset : Bitfield<2,1> {};
+    };
+
+    struct S2MM_VDMASR : Register<0x34, 32>
+    {
+        struct EOLLateErr : Bitfield<15,1> {};
+        struct Err_Irq : Bitfield<14,1> {};
+        struct SOFLateErr : Bitfield<11,1> {};
+        struct EOLEarlyErr : Bitfield<8,1> {};
+        struct SOFEarlyErr : Bitfield<7,1> {};
+        struct VDMADecErr : Bitfield<6,1> {};
+        struct DMASlvErr : Bitfield<5,1> {};
+        struct DMAIntErr : Bitfield<4,1> {};
+        struct Halted : Bitfield<0,1> {};
+    };
+
+    struct S2MM_REG_INDEX : Register<0x44, 32>
+    {
+        struct S2MM_Reg_Index : Bitfield<0,1> {};
+    };
+
+    struct MM2S_VSIZE : Register<0x50, 32>
+    {
+        struct Vertical_Size : Bitfield<0,13> {};
+    };
+
+    struct MM2S_HSIZE : Register<0x54, 32>
+    {
+        struct Horizontal_Size : Bitfield<0,16> {};
+    };
+
+    struct MM2S_FRMDLY_STRIDE : Register<0x58, 32>
+    {
+        struct Frame_Delay : Bitfield<24,5> {};
+        struct Stride : Bitfield<0,16> {};
+    };
+
+    struct MM2S_START_ADDRESS : Register<0x5c, 32> {};
+
+    struct S2MM_VSIZE : Register<0xa0, 32>
+    {
+        struct Vertical_Size : Bitfield<0,13> {};
+    };
+
+    struct S2MM_HSIZE : Register<0xa4, 32>
+    {
+        struct Horizontal_Size : Bitfield<0,16> {};
+    };
+
+    struct S2MM_FRMDLY_STRIDE : Register<0xa8, 32>
+    {
+        struct Frame_Delay : Bitfield<24,5> {};
+        struct Stride : Bitfield<0,16> {};
+    };
+
+    struct S2MM_START_ADDRESS : Register<0xac, 32> {};
+
+};
+
+#endif // _VDMA_H_

--- a/repos/ports/run/lighttpd.run
+++ b/repos/ports/run/lighttpd.run
@@ -124,8 +124,21 @@ build_boot_image $boot_modules
 
 append_if [have_spec x86]     qemu_args " -net nic,model=e1000 "
 append_if [have_spec lan9118] qemu_args " -net nic,model=lan9118 "
+append_if [have_spec cadence_gem] qemu_args " -net nic,model=cadence_gem"
 
 append qemu_args " -net user -redir tcp:5555::80 "
 append qemu_args " -nographic -serial mon:stdio "
+
+
+# Only for testing the network interface
+# before starting run
+# $ sudo brctl addbr br0
+# to create an bridge device and run
+# $ sudo brctl addif br0 eth0
+# to add the host ethernet interface to this bridge device.
+# To verify this configiration you can run
+# $ sudo brctl show
+#append qemu_args " -net tap"
+
 
 run_genode_until forever

--- a/tool/builddir/etc/build.conf.hw_parallella
+++ b/tool/builddir/etc/build.conf.hw_parallella
@@ -1,0 +1,7 @@
+REPOSITORIES += $(GENODE_DIR)/repos/base-hw
+
+##
+## Kernel-specific run tool configuration
+##
+
+RUN_OPT = --include boot_dir/hw --include image/uboot

--- a/tool/builddir/etc/build.conf.hw_zedboard
+++ b/tool/builddir/etc/build.conf.hw_zedboard
@@ -1,0 +1,7 @@
+REPOSITORIES += $(GENODE_DIR)/repos/base-hw
+
+##
+## Kernel-specific run tool configuration
+##
+
+RUN_OPT = --include boot_dir/hw --include image/uboot

--- a/tool/builddir/etc/build.conf.hw_zynq
+++ b/tool/builddir/etc/build.conf.hw_zynq
@@ -1,0 +1,7 @@
+REPOSITORIES += $(GENODE_DIR)/repos/base-hw
+
+##
+## Kernel-specific run tool configuration
+##
+
+RUN_OPT = --include boot_dir/hw --include power_on/qemu --include log/qemu

--- a/tool/create_builddir
+++ b/tool/create_builddir
@@ -37,6 +37,9 @@ usage:
 	@echo "                  'hw_arndale'"
 	@echo "                  'hw_odroid_xu'"
 	@echo "                  'hw_rpi'"
+	@echo "                  'hw_zynq'"
+	@echo "                  'hw_parallella'"
+	@echo "                  'hw_zedboard'"
 	@echo "                  'hw_x86_64'"
 	@echo "                  'foc_x86_32'"
 	@echo "                  'foc_x86_64'"
@@ -160,7 +163,7 @@ endif
 #
 # Add ARM drivers repositories to ARM build directories
 #
-ifeq ($(filter-out foc_panda foc_arndale hw_panda hw_arndale hw_odroid_xu foc_imx53,$(PLATFORM)),)
+ifeq ($(filter-out foc_panda foc_arndale hw_panda hw_rpi hw_zynq hw_parallella hw_zedboard hw_arndale hw_odroid_xu foc_imx53,$(PLATFORM)),)
 $(BUILD_DIR)/etc/build.conf::
 	@cat $(BUILD_CONF).drivers_arm >> $@
 endif
@@ -254,6 +257,15 @@ hw_arndale::
 hw_rpi::
 	@echo "SPECS = genode hw_rpi" > $(BUILD_DIR)/etc/specs.conf
 	@echo "SPECS += perf_counter" >> $(BUILD_DIR)/etc/specs.conf
+
+hw_zynq::
+	@echo "SPECS = genode hw_zynq" > $(BUILD_DIR)/etc/specs.conf
+
+hw_parallella::
+	@echo "SPECS = genode hw_parallella" > $(BUILD_DIR)/etc/specs.conf
+
+hw_zedboard::
+	@echo "SPECS = genode hw_zedboard" > $(BUILD_DIR)/etc/specs.conf
 
 hw_odroid_xu::
 	@echo "SPECS = genode hw_odroid_xu" > $(BUILD_DIR)/etc/specs.conf

--- a/tool/run/power_on/qemu
+++ b/tool/run/power_on/qemu
@@ -51,6 +51,7 @@ proc run_power_on { } {
 	}
 	if {[have_spec platform_vpb926]} { append qemu_args " -M versatilepb     -m 128 " }
 	if {[have_spec platform_vea9x4]} { append qemu_args " -M vexpress-a9 -cpu cortex-a9 -m 256 " }
+	if {[have_spec platform_zynq]}   { append qemu_args " -M xilinx-zynq-a9 -cpu cortex-a9 -m 256 " }
 	if {[have_spec hw_x86_64]} {
 		regsub -all {\-m ([0-9])+} $qemu_args "" qemu_args
 		append qemu_args " -m 512 "


### PR DESCRIPTION
Supporting Qemu (hw_zynq), parallella board (hw_parallella) and zedboard
(hw_zedboard).

Device drivers: nic, gpio, vdma, i2c

Thanks to Timo Wischer and Mark Albers for their contributions.