### PR TITLE
gpio_drv: Adding dummy compilation unit needed to link a valid target

### DIFF
--- a/repos/os/src/drivers/gpio/rpi/empty.cc
+++ b/repos/os/src/drivers/gpio/rpi/empty.cc
@@ -1,0 +1,3 @@
+/*
+ * Dummy compilation unit needed to link a valid target.
+ */

--- a/repos/os/src/drivers/gpio/rpi/target.mk
+++ b/repos/os/src/drivers/gpio/rpi/target.mk
@@ -1,3 +1,4 @@
 TARGET   = gpio_drv
-REQUIRES = rpi
+REQUIRES = platform_rpi
 LIBS    += gpio
+SRC_CC   = empty.cc


### PR DESCRIPTION
fix #1683

Signed-off-by: Reinier Millo Sánchez <rmillo@uclv.cu>