### PR TITLE
Run: Support loading images via iPXE

### DIFF
--- a/tool/run/boot_dir/fiasco
+++ b/tool/run/boot_dir/fiasco
@@ -144,4 +144,10 @@ proc run_boot_dir {binaries} {
 
 		generate_tftp_config
 	}
+
+	if {[have_include "load/ipxe"]} {
+		create_ipxe_iso_config
+		update_ipxe_boot_dir
+		create_symlink_for_iso
+	}
 }

--- a/tool/run/boot_dir/foc
+++ b/tool/run/boot_dir/foc
@@ -183,6 +183,12 @@ proc run_boot_dir_x86 {binaries} {
 
 		generate_tftp_config
 	}
+
+	if {[have_include "load/ipxe"]} {
+		create_ipxe_iso_config
+		update_ipxe_boot_dir
+		create_symlink_for_iso
+	}
 }
 
 

--- a/tool/run/boot_dir/nova
+++ b/tool/run/boot_dir/nova
@@ -93,4 +93,10 @@ proc run_boot_dir {binaries} {
 
 		generate_tftp_config
 	}
+
+	if {[have_include "load/ipxe"]} {
+		create_ipxe_iso_config
+		update_ipxe_boot_dir
+		create_symlink_for_iso
+	}
 }

--- a/tool/run/load/ipxe
+++ b/tool/run/load/ipxe
@@ -46,3 +46,23 @@ proc create_symlink_for_iso { } {
 proc update_ipxe_boot_dir { } {
 	exec ln -sfn [pwd]/[run_dir] [load_ipxe_base_dir]/[load_ipxe_boot_dir]
 }
+
+##
+# Create iPXE config file which directly boots an ISO file.
+#
+proc create_ipxe_iso_config { } {
+	if {[have_include "image/iso"]} {
+		set fh [open "[run_dir]/boot.cfg" "WRONLY CREAT TRUNC"]
+		puts $fh "#!ipxe"
+		puts $fh "sanboot [run_name].iso || goto failed"
+		puts $fh
+		puts $fh ":failed"
+		puts $fh "echo Booting failed, dropping to shell"
+		puts $fh "shell"
+		puts $fh "boot"
+		close $fh
+	} else {
+		puts "Warning, iPXE requires ISO image."
+		exit -1
+	}
+}

--- a/tool/run/load/ipxe
+++ b/tool/run/load/ipxe
@@ -1,0 +1,48 @@
+##
+# Load files needed by the scenario via iPXE/HTTP
+#
+# \param --load-ipxe-base-dir    base directory of iPXE/HTTP server
+# \param --load-ipxe-boot-dir    boot directory relative to HTTP base
+#
+
+source [genode_dir]/tool/run/load.inc
+
+
+##
+# The files are loaded implicitly via iPXE/HTTP to the target machine
+#
+proc run_load { } {
+	global load_spawn_id
+	set load_spawn_id -1
+	return true
+}
+
+
+proc load_ipxe_base_dir { } { return [get_cmd_arg --load-ipxe-base-dir ""] }
+
+
+proc load_ipxe_boot_dir { } { return [get_cmd_arg --load-ipxe-boot-dir ""] }
+
+
+##
+# Install files needed to boot via iPXE
+#
+proc install_bender_to_run_dir { } {
+	exec mkdir -p [run_dir]/boot
+	exec cp [genode_dir]/tool/boot/bender [run_dir]/boot/bender
+}
+
+
+##
+# Create symlink for ISO image in current run directory.
+#
+proc create_symlink_for_iso { } {
+	exec ln -sfn [pwd]/[run_dir].iso [pwd]/[run_dir]/[run_name].iso
+}
+
+##
+# Update iPXE boot directory to point to current run directory.
+#
+proc update_ipxe_boot_dir { } {
+	exec ln -sfn [pwd]/[run_dir] [load_ipxe_base_dir]/[load_ipxe_boot_dir]
+}


### PR DESCRIPTION
These changes add a run script to support deploying images using [iPXE](http://ipxe.org/). iPXE is an open source network boot firmware that, among other things, supports booting ISO images via HTTP directly from a web server.

The following build.conf/RUN_OPT parameters can be used to configure the iPXE/HTTP setup:

--load-ipxe-base-dir: This parameter specifies the base directory of the HTTP server from which the target machine downloads the files, e.g. /srv/www.
--load-ipxe-boot-dir: The directory relative to iPXE base dir which contains the iPXE chainload configuration and all necessary files.

The target machine is expected to request the following iPXE configuration via HTTP: http://${HOST_URL}/${ipxe-boot-dir}/boot.cfg

This can be achieved by building iPXE with the following embedded script:

    #!ipxe
    dhcp
    chain http://${HOST_URL}/${ipxe-boot-dir}/boot.cfg

For additional information on iPXE an embedded scripts please refer to the [iPXE website](http://ipxe.org/howto/chainloading#breaking_the_loop_with_an_embedded_script).

NOTE: the webserver serving the ISO image must support ranged requests (see [here](http://forum.ipxe.org/showthread.php?tid=7295&pid=10482#pid10482)). 