### PR TITLE
hw_x86_64_muen: Add support for Message Signaled Interrupts

### DIFF
--- a/repos/base-hw/src/core/include/irq_session_component.h
+++ b/repos/base-hw/src/core/include/irq_session_component.h
@@ -31,6 +31,8 @@ class Genode::Irq_session_component : public Rpc_object<Irq_session>,
 		unsigned         _irq_number;
 		Range_allocator *_irq_alloc;
 		Genode::uint8_t  _kernel_object[sizeof(Kernel::User_irq)];
+		bool             _is_msi;
+		addr_t           _address, _value;
 
 		Signal_context_capability _sig_cap;
 
@@ -58,8 +60,16 @@ class Genode::Irq_session_component : public Rpc_object<Irq_session>,
 
 		void ack_irq() override;
 		void sigh(Signal_context_capability) override;
-		Info info() override {
-			return { .type = Genode::Irq_session::Info::Type::INVALID }; }
+
+		Info info() override
+		{
+			if (!_is_msi) {
+				return { .type = Info::Type::INVALID };
+			}
+			return { .type    = Info::Type::MSI,
+			         .address = _address,
+			         .value   = _value };
+		}
 };
 
 #endif /* _INCLUDE__IRQ_SESSION_COMPONENT_H_ */

--- a/repos/base-hw/src/core/include/platform.h
+++ b/repos/base-hw/src/core/include/platform.h
@@ -122,6 +122,19 @@ namespace Genode {
 			                           unsigned polarity);
 
 			/**
+			 * Get MSI-related parameters from device PCI config space
+			 *
+			 * \param mmconf      PCI config space address of device
+			 * \param address     MSI address register value to use
+			 * \param data        MSI data register value to use
+			 * \param irq_number  IRQ to use
+			 *
+			 * \return  true if the device is MSI-capable, false if not
+			 */
+			static bool get_msi_params(const addr_t mmconf,
+			                           addr_t &address, addr_t &data,
+			                           unsigned &irq_number);
+			/**
 			 * Return address of cores translation table allocator
 			 */
 			static addr_t core_translation_tables();

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/sinfo.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/sinfo.h
@@ -58,6 +58,15 @@ class Genode::Sinfo
 			bool has_vector;
 		};
 
+		/* Structure holding information about PCI devices */
+		struct Dev_info {
+			uint16_t sid;
+			uint16_t irte_start;
+			uint8_t irq_start;
+			uint8_t ir_count;
+			bool msi_capable;
+		};
+
 		/*
 		 * Check Muen sinfo Magic.
 		 */
@@ -80,6 +89,14 @@ class Genode::Sinfo
 		 */
 		static bool get_memregion_info(const char * const name,
 				struct Memregion_info *memregion);
+
+		/*
+		 * Return information for PCI device with given SID.
+		 *
+		 * The function returns false if no device information for the
+		 * specified device exists.
+		 */
+		static bool get_dev_info(const uint16_t sid, struct Dev_info *dev);
 
 		/*
 		 * Channel callback.

--- a/repos/base-hw/src/core/irq_session_component.cc
+++ b/repos/base-hw/src/core/irq_session_component.cc
@@ -66,7 +66,8 @@ Irq_session_component::~Irq_session_component()
 Irq_session_component::Irq_session_component(Range_allocator * const irq_alloc,
                                              const char      * const      args)
 :
-	_irq_number(Platform::irq(_find_irq_number(args))), _irq_alloc(irq_alloc)
+	_irq_number(Platform::irq(_find_irq_number(args))), _irq_alloc(irq_alloc),
+	_is_msi(false), _address(0), _value(0)
 {
 	long const msi = Arg_string::find_arg(args, "device_config_phys").long_value(0);
 	if (msi)

--- a/repos/base-hw/src/core/irq_session_component.cc
+++ b/repos/base-hw/src/core/irq_session_component.cc
@@ -69,9 +69,15 @@ Irq_session_component::Irq_session_component(Range_allocator * const irq_alloc,
 	_irq_number(Platform::irq(_find_irq_number(args))), _irq_alloc(irq_alloc),
 	_is_msi(false), _address(0), _value(0)
 {
-	long const msi = Arg_string::find_arg(args, "device_config_phys").long_value(0);
-	if (msi)
-		throw Root::Unavailable();
+	const long mmconf =
+		Arg_string::find_arg(args, "device_config_phys").long_value(0);
+
+	if (mmconf) {
+		_is_msi =
+			Platform::get_msi_params(mmconf, _address, _value, _irq_number);
+		if (!_is_msi)
+			throw Root::Unavailable();
+	}
 
 	/* allocate interrupt */
 	if (_irq_alloc->alloc_addr(1, _irq_number).is_error()) {

--- a/repos/base-hw/src/core/spec/arm/platform_support.cc
+++ b/repos/base-hw/src/core/spec/arm/platform_support.cc
@@ -36,3 +36,10 @@ void Platform::_init_io_mem_alloc()
 
 
 long Platform::irq(long const user_irq) { return user_irq; }
+
+
+bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
+                              addr_t &data, unsigned &irq_number)
+{
+	return false;
+}

--- a/repos/base-hw/src/core/spec/x86_64/muen/musinfo.h
+++ b/repos/base-hw/src/core/spec/x86_64/muen/musinfo.h
@@ -42,18 +42,31 @@ struct resource_type {
 	char padding[6];
 } __attribute__((packed, aligned (8)));
 
+struct dev_info_type {
+	uint16_t sid;
+	uint16_t irte_start;
+	uint8_t irq_start;
+	uint8_t ir_count;
+	uint8_t flags;
+	char padding[1];
+} __attribute__((packed, aligned (8)));
+
+#define DEV_MSI_FLAG  (1 << 0)
+
 struct subject_info_type {
 	uint64_t magic;
 	uint8_t resource_count;
 	uint8_t memregion_count;
 	uint8_t channel_info_count;
-	char padding[5];
+	uint8_t dev_info_count;
+	char padding[4];
 	uint64_t tsc_khz;
 	uint64_t tsc_schedule_start;
 	uint64_t tsc_schedule_end;
 	struct resource_type resources[MAX_RESOURCE_COUNT];
 	struct memregion_type memregions[MAX_RESOURCE_COUNT];
 	struct channel_info_type channels_info[MAX_RESOURCE_COUNT];
+	struct dev_info_type dev_info[MAX_RESOURCE_COUNT];
 } __attribute__((packed, aligned (8)));
 
 #endif /* MUSINFO_H_  */

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -12,10 +12,55 @@
  * under the terms of the GNU General Public License version 2.
  */
 
+/* Genode includes */
+#include <util/mmio.h>
+
 /* core includes */
 #include <platform.h>
+#include <sinfo.h>
 
 using namespace Genode;
+
+struct Mmconf_address : Register<64>
+{
+	enum { PCI_CONFIG_BASE = 0xf8000000 };
+
+	struct Sid : Bitfield<12, 16> { };
+
+	/**
+	 * Calculate SID (source-id, see VT-d spec section 3.4.1) from device PCI
+	 * config space address.
+	 */
+	static unsigned to_sid(access_t const addr) {
+		return Sid::get(addr - PCI_CONFIG_BASE); }
+};
+
+struct Msi_handle : Register<16>
+{
+	struct Bits_0 : Bitfield<0, 15> { };
+	struct Bits_1 : Bitfield<15, 1> { };
+};
+
+struct Msi_address : Register<32>
+{
+	enum { BASE = 0xfee00010 };
+
+	struct Bits_0 : Bitfield<5, 15> { };
+	struct Bits_1 : Bitfield<2, 1> { };
+
+	/**
+	 * Return MSI address register value for given handle to enable Interrupt
+	 * Requests in Remappable Format, see VT-d specification section 5.1.2.2.
+	 */
+	static access_t to_msi_addr(Msi_handle::access_t const handle)
+	{
+		access_t addr = BASE;
+		Bits_0::set(addr, Msi_handle::Bits_0::get(handle));
+		Bits_1::set(addr, Msi_handle::Bits_1::get(handle));
+		return addr;
+	}
+};
+
 
 Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 {
@@ -23,6 +68,7 @@ Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 	{
 		/* Sinfo pages */
 		{ 0x000e00000000, 0x7000 },
+
 		/* Timer page */
 		{ 0x000e00010000, 0x1000 },
 	};
@@ -36,7 +82,25 @@ void Platform::setup_irq_mode(unsigned, unsigned, unsigned) { }
 bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
                               addr_t &data, unsigned &irq_number)
 {
-	return false;
+	const unsigned sid = Mmconf_address::to_sid(mmconf);
+
+	struct Sinfo::Dev_info dev_info;
+	if (!Sinfo::get_dev_info(sid, &dev_info)) {
+		PERR("error retrieving Muen info for device with SID 0x%x", sid);
+		return false;
+	}
+	if (!dev_info.msi_capable) {
+		PERR("device 0x%x not configured for MSI", sid);
+		return false;
+	}
+
+	data = 0;
+	address = Msi_address::to_msi_addr(dev_info.irte_start);
+	irq_number = dev_info.irq_start;
+
+	PDBG("enabling MSI for device with SID 0x%x: IRTE %d, IRQ %d",
+		 sid, dev_info.irte_start, irq_number);
+	return true;
 }
 
 

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -29,7 +29,15 @@ Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
 }
 
+
 void Platform::setup_irq_mode(unsigned, unsigned, unsigned) { }
+
+
+bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
+                              addr_t &data, unsigned &irq_number)
+{
+	return false;
+}
 
 
 Native_region * Platform::_ram_regions(unsigned const i)

--- a/repos/base-hw/src/core/spec/x86_64/muen/sinfo.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/sinfo.cc
@@ -116,6 +116,19 @@ static bool is_channel(const struct resource_type * const resource)
 }
 
 
+/* Fill dev struct with data from PCI device info given by index */
+static void fill_dev_data(uint8_t idx, struct Genode::Sinfo::Dev_info *dev)
+{
+	const struct dev_info_type dev_info = sinfo->dev_info[idx];
+
+	dev->sid         = dev_info.sid;
+	dev->irte_start  = dev_info.irte_start;
+	dev->irq_start   = dev_info.irq_start;
+	dev->ir_count    = dev_info.ir_count;
+	dev->msi_capable = dev_info.flags & DEV_MSI_FLAG;
+}
+
+
 Sinfo::Sinfo()
 {
 	if (!check_magic()) {
@@ -169,6 +182,23 @@ bool Sinfo::get_memregion_info(const char * const name,
 		if (is_memregion(&sinfo->resources[i]) &&
 			strcmp(sinfo->resources[i].name.data, name) == 0) {
 			fill_memregion_data(i, memregion);
+			return true;
+		}
+	}
+	return false;
+}
+
+
+bool Sinfo::get_dev_info(const uint16_t sid, struct Dev_info *dev)
+{
+	int i;
+
+	if (!check_magic())
+		return false;
+
+	for (i = 0; i < sinfo->dev_info_count; i++) {
+		if (sinfo->dev_info[i].sid == sid) {
+			fill_dev_data(i, dev);
 			return true;
 		}
 	}

--- a/repos/base-hw/src/core/spec/x86_64/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/platform_support.cc
@@ -49,6 +49,13 @@ void Platform::setup_irq_mode(unsigned irq_number, unsigned trigger,
 }
 
 
+bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
+                              addr_t &data, unsigned &irq_number)
+{
+	return false;
+}
+
+
 Native_region * Platform::_ram_regions(unsigned const i)
 {
 	static Native_region _regions[16];

--- a/repos/base/run/platform_drv.inc
+++ b/repos/base/run/platform_drv.inc
@@ -22,10 +22,11 @@ proc append_platform_drv_build_components {} {
 proc append_platform_drv_boot_modules {} {
 	global boot_modules
 
-	lappend_if [have_platform_drv] boot_modules platform_drv
-	lappend_if [have_spec acpi]    boot_modules acpi_drv
-	lappend_if [have_spec acpi]    boot_modules report_rom
-	lappend_if [have_spec nova]    boot_modules device_pd
+	lappend_if [have_platform_drv]        boot_modules platform_drv
+	lappend_if [have_spec acpi]           boot_modules acpi_drv
+	lappend_if [have_spec acpi]           boot_modules report_rom
+	lappend_if [have_spec nova]           boot_modules device_pd
+	lappend_if [have_spec hw_x86_64_muen] boot_modules acpi
 }
 
 proc platform_drv_policy {} {
@@ -121,7 +122,7 @@ proc append_platform_drv_config {} {
 			<any-service> <parent/> </any-service>
 		</route>}
 
-		if {[have_spec acpi] || [have_spec arm]} {
+		if {[have_spec acpi] || [have_spec arm] || [have_spec hw_x86_64_muen]} {
 
 		append config {
 		<config>}

--- a/tool/run/boot_dir/hw
+++ b/tool/run/boot_dir/hw
@@ -30,6 +30,13 @@ proc run_boot_dir {binaries} {
 		set core_target "core"
 	}
 
+	# generate static ACPI report for platform driver on Muen
+	if {[have_spec "hw_x86_64_muen"]} {
+		set fh [open "bin/acpi" "WRONLY CREAT TRUNC"]
+		puts $fh "<acpi><bdf start=\"0\" count=\"16384\" base=\"0xf8000000\"/></acpi>"
+		close $fh
+	}
+
 	# strip binaries
 	copy_and_strip_genode_binaries_to_run_dir $binaries
 


### PR DESCRIPTION
This patch set adds support for MSIs to the `hw_x86_64_muen` platform.

The  first patch enables the ACPI functionality in the platform_drv on `hw_x86_64_muen` and
provides a simple generated XML report as ROM session in order to make the PCI configuration space available.

The base-hw `Irq_session_component` class is  extended with member variables to support MSI mode of operation. Values for MSI are only returned if the private `_is_msi` member is set to true.

The platform-specific MSI code is factored out to the `get_msi_params` function which returns false if either the platform or the device does not support MSI mode of operation.

The Muen Sinfo API is extended to retrieve PCI device information via the  `get_dev_info` function. The provided information is required to calculate MSI address/data register values in remappable format (see Intel VT-d specification, section 5.1.2.2).

The `get_msi_params` function on `hw_x86_64_muen` implements support for MSIs by using information provided via the `Sinfo::get_dev_info` function.

The changes are tested with the autopilot tool  for both `hw_x86_64` and `hw_x86_64_muen`.