### PR TITLE
CPU execution time for Fiasco.OC threads.

### DIFF
--- a/repos/base-foc/src/core/include/platform_thread.h
+++ b/repos/base-foc/src/core/include/platform_thread.h
@@ -175,7 +175,7 @@ namespace Genode {
 			/**
 			 * Return execution time consumed by the thread
 			 */
-			unsigned long long execution_time() const { return 0; }
+			unsigned long long execution_time() const;
 
 
 			/*******************************

--- a/repos/base-foc/src/core/platform_thread.cc
+++ b/repos/base-foc/src/core/platform_thread.cc
@@ -266,6 +266,19 @@ Weak_ptr<Address_space> Platform_thread::address_space()
 }
 
 
+unsigned long long Platform_thread::execution_time() const
+{
+	unsigned long long time = 0;
+
+	if (_utcb) {
+		l4_thread_stats_time(_thread.local.dst());
+		time = *(l4_kernel_clock_t*)&l4_utcb_mr()->mr[0];
+	}
+
+	return time;
+}
+
+
 Platform_thread::Platform_thread(const char *name, unsigned prio, addr_t)
 : _state(DEAD),
   _core_thread(false),


### PR DESCRIPTION
This commit adds an implementation for `Platform_thread::execution_time()` on the Fiasco.OC kernel which thus far has only been available to the NOVA platform.
