### PR TITLE
tcp_terminal: disconnect socket if there was no data

### DIFF
--- a/repos/gems/src/server/tcp_terminal/main.cc
+++ b/repos/gems/src/server/tcp_terminal/main.cc
@@ -191,6 +191,11 @@ class Open_socket : public Genode::List<Open_socket>::Element
 			/* read from socket */
 			_read_buf_bytes_used = ::read(_sd, _read_buf, sizeof(_read_buf));
 
+			if (_read_buf_bytes_used == 0) {
+				_sd = -1;
+				return;
+			}
+
 			/* notify client about bytes available for reading */
 			if (_read_avail_sigh.valid())
 				Genode::Signal_transmitter(_read_avail_sigh).submit();


### PR DESCRIPTION
The tcp_terminal kept the socket open even though the client disconnected. As a result, reconnecting to the tcp_terminal was not working.