### PR TITLE
base-hw: fix SCU initialization for zynq-based boards

### DIFF
--- a/repos/base-hw/src/core/include/spec/cortex_a9/scu.h
+++ b/repos/base-hw/src/core/include/spec/cortex_a9/scu.h
@@ -66,6 +66,6 @@ class Genode::Scu : Genode::Mmio
 		void enable()
 		{
 			if (_board.errata(Board::ARM_764369)) write<Dcr::Bit_0>(1);
-			write<Cr>(Cr::Enable::bits(1));
+			write<Cr::Enable>(1);
 		}
 };


### PR DESCRIPTION
The old implementation cleared all other bits in the SCU control
register when enabling the SCU, which broke the kernel startup on zynq-
based boards.
By only raising the enable bit, we can keep the initial/default state
e.g. as set up by uboot.