### PR TITLE
base-hw: refactor core.mk and core.inc files

### DIFF
--- a/repos/base-hw/lib/mk/core.inc
+++ b/repos/base-hw/lib/mk/core.inc
@@ -11,8 +11,8 @@ LIBS += core-perf_counter
 LIBS += base-common
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include $(BASE_DIR)/src/core/include
-INC_DIR += $(REP_DIR)/src/include      $(BASE_DIR)/src/include
+INC_DIR += $(BASE_HW_DIR)/src/core/include $(BASE_DIR)/src/core/include
+INC_DIR += $(BASE_HW_DIR)/src/include      $(BASE_DIR)/src/include
 
 # add C++ sources
 SRC_CC += console.cc
@@ -70,11 +70,11 @@ ifneq ($(wildcard $(BUILD_BASE_DIR)/boot_modules.s),)
   INC_DIR += $(BOOT_MODULES_VPATH)
 else
   # use dummy boot-modules per default
-  BOOT_MODULES_VPATH = $(REP_DIR)/src/core/
+  BOOT_MODULES_VPATH = $(BASE_HW_DIR)/src/core/
 endif
 vpath boot_modules.s $(BOOT_MODULES_VPATH)
 
 # declare source locations
-vpath %  $(REP_DIR)/src/core
+vpath %  $(BASE_HW_DIR)/src/core
 vpath % $(BASE_DIR)/src/core
 vpath % $(BASE_DIR)/src/lib/startup

--- a/repos/base-hw/lib/mk/spec/arm/core.inc
+++ b/repos/base-hw/lib/mk/spec/arm/core.inc
@@ -5,7 +5,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/arm
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/arm
 
 # add C++ sources
 SRC_CC += spec/arm/kernel/thread.cc
@@ -18,4 +18,4 @@ SRC_S += spec/arm/kernel/crt0.s
 SRC_S += spec/arm/crt0.s
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/core.inc
+include $(BASE_HW_DIR)/lib/mk/core.inc

--- a/repos/base-hw/lib/mk/spec/arm_v6/core.inc
+++ b/repos/base-hw/lib/mk/spec/arm_v6/core.inc
@@ -6,7 +6,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/arm_v6
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/arm_v6
 
 # add C++ sources
 SRC_CC += spec/arm_v6/cpu.cc
@@ -20,4 +20,4 @@ SRC_CC += kernel/kernel.cc
 SRC_S += spec/arm_v6/mode_transition.s
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/arm/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/arm/core.inc

--- a/repos/base-hw/lib/mk/spec/arm_v7/core.inc
+++ b/repos/base-hw/lib/mk/spec/arm_v7/core.inc
@@ -5,7 +5,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/arm_v7
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/arm_v7
 
 # add C++ sources
 SRC_CC += spec/arm_v7/cpu.cc
@@ -14,4 +14,4 @@ SRC_CC += spec/arm_v7/cpu.cc
 SRC_S += spec/arm_v7/mode_transition.s
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/arm/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/arm/core.inc

--- a/repos/base-hw/lib/mk/spec/arndale/core.mk
+++ b/repos/base-hw/lib/mk/spec/arndale/core.mk
@@ -20,5 +20,9 @@ SRC_CC += spec/arm_v7/virtualization/vm_session_component.cc
 # add assembly sources
 SRC_S += spec/arm_v7/virtualization/mode_transition.s
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/exynos5/core.inc

--- a/repos/base-hw/lib/mk/spec/cortex_a15/core.inc
+++ b/repos/base-hw/lib/mk/spec/cortex_a15/core.inc
@@ -5,8 +5,8 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/cortex_a15
-INC_DIR += $(REP_DIR)/src/core/include/spec/arm_gic
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/cortex_a15
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/arm_gic
 
 # add C++ sources
 SRC_CC += spec/cortex_a15/cpu.cc
@@ -18,5 +18,5 @@ SRC_CC += spec/arm/smp/kernel/cpu.cc
 SRC_S  += spec/arm/smp/kernel/crt0.s
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/smp/core.inc
-include $(REP_DIR)/lib/mk/spec/arm_v7/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/smp/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/arm_v7/core.inc

--- a/repos/base-hw/lib/mk/spec/cortex_a8/core.inc
+++ b/repos/base-hw/lib/mk/spec/cortex_a8/core.inc
@@ -5,7 +5,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/cortex_a8
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/cortex_a8
 
 # add C++ sources
 SRC_CC += spec/cortex_a8/cpu.cc
@@ -15,4 +15,4 @@ SRC_CC += spec/arm/kernel/thread_update_pd.cc
 SRC_CC += kernel/kernel.cc
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/arm_v7/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/arm_v7/core.inc

--- a/repos/base-hw/lib/mk/spec/cortex_a9/core.inc
+++ b/repos/base-hw/lib/mk/spec/cortex_a9/core.inc
@@ -5,8 +5,8 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/cortex_a9
-INC_DIR += $(REP_DIR)/src/core/include/spec/arm_gic
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/cortex_a9
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/arm_gic
 
 # add C++ sources
 SRC_CC += spec/cortex_a9/kernel/cpu.cc
@@ -22,5 +22,5 @@ SRC_CC += kernel/vm_thread.cc
 SRC_S  += spec/arm/smp/kernel/crt0.s
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/smp/core.inc
-include $(REP_DIR)/lib/mk/spec/arm_v7/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/smp/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/arm_v7/core.inc

--- a/repos/base-hw/lib/mk/spec/exynos5/core.inc
+++ b/repos/base-hw/lib/mk/spec/exynos5/core.inc
@@ -5,11 +5,11 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/exynos5
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/exynos5
 
 # add C++ sources
 SRC_CC += spec/exynos5/platform_support.cc
 SRC_CC += spec/exynos5/cpu.cc
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/cortex_a15/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/cortex_a15/core.inc

--- a/repos/base-hw/lib/mk/spec/imx6/core.mk
+++ b/repos/base-hw/lib/mk/spec/imx6/core.mk
@@ -14,5 +14,9 @@ INC_DIR += $(REP_DIR)/src/core/include/spec/imx
 SRC_CC += platform_services.cc
 SRC_CC += spec/imx6/platform_support.cc
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/spec/odroid_xu/core.mk
+++ b/repos/base-hw/lib/mk/spec/odroid_xu/core.mk
@@ -11,5 +11,9 @@ SRC_CC += spec/arm_gic/pic.cc
 SRC_CC += kernel/vm_thread.cc
 SRC_CC += platform_services.cc
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/exynos5/core.inc

--- a/repos/base-hw/lib/mk/spec/panda/core.mk
+++ b/repos/base-hw/lib/mk/spec/panda/core.mk
@@ -13,5 +13,9 @@ INC_DIR += $(REP_DIR)/src/core/include/spec/tl16c750
 SRC_CC += platform_services.cc
 SRC_CC += spec/panda/platform_support.cc
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/spec/pbxa9/core.mk
+++ b/repos/base-hw/lib/mk/spec/pbxa9/core.mk
@@ -14,5 +14,9 @@ SRC_CC += platform_services.cc
 SRC_CC += spec/pbxa9/platform_support.cc
 SRC_CC += spec/pbxa9/board.cc
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/spec/riscv/core.mk
+++ b/repos/base-hw/lib/mk/spec/riscv/core.mk
@@ -18,5 +18,9 @@ SRC_S += spec/riscv/mode_transition.s
 SRC_S += spec/riscv/kernel/crt0.s
 SRC_S += spec/riscv/crt0.s
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/core.inc

--- a/repos/base-hw/lib/mk/spec/rpi/core.mk
+++ b/repos/base-hw/lib/mk/spec/rpi/core.mk
@@ -12,5 +12,9 @@ INC_DIR += $(REP_DIR)/src/core/include/spec/pl011
 SRC_CC += platform_services.cc
 SRC_CC += spec/rpi/platform_support.cc
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/arm_v6/core.inc

--- a/repos/base-hw/lib/mk/spec/smp/core.inc
+++ b/repos/base-hw/lib/mk/spec/smp/core.inc
@@ -5,7 +5,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/smp
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/smp
 
 # add C++ sources
 SRC_CC += spec/smp/kernel/kernel.cc

--- a/repos/base-hw/lib/mk/spec/x86/core.inc
+++ b/repos/base-hw/lib/mk/spec/x86/core.inc
@@ -6,7 +6,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/x86
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/x86
 
 # add C++ sources
 SRC_CC += kernel/kernel.cc
@@ -22,4 +22,4 @@ SRC_CC += spec/x86/io_port_session_component.cc
 SRC_CC += spec/x86/platform_services.cc
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/core.inc
+include $(BASE_HW_DIR)/lib/mk/core.inc

--- a/repos/base-hw/lib/mk/spec/x86_64/core.inc
+++ b/repos/base-hw/lib/mk/spec/x86_64/core.inc
@@ -6,7 +6,7 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/x86_64
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/x86_64
 
 # add assembly sources
 SRC_S += spec/x86_64/mode_transition.s
@@ -20,4 +20,4 @@ SRC_CC += spec/x86_64/tss.cc
 SRC_CC += spec/x86_64/kernel/cpu_context.cc
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/x86/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/x86/core.inc

--- a/repos/base-hw/lib/mk/spec/zynq/core.inc
+++ b/repos/base-hw/lib/mk/spec/zynq/core.inc
@@ -5,11 +5,11 @@
 #
 
 # add include paths
-INC_DIR += $(REP_DIR)/src/core/include/spec/zynq
+INC_DIR += $(BASE_HW_DIR)/src/core/include/spec/zynq
 
 # add C++ sources
 SRC_CC += platform_services.cc
 SRC_CC += spec/zynq/platform_support.cc
 
 # include less specific configuration
-include $(REP_DIR)/lib/mk/spec/cortex_a9/core.inc
+include $(BASE_HW_DIR)/lib/mk/spec/cortex_a9/core.inc

--- a/repos/base-hw/lib/mk/spec/zynq_qemu/core.mk
+++ b/repos/base-hw/lib/mk/spec/zynq_qemu/core.mk
@@ -8,5 +8,9 @@
 INC_DIR += $(REP_DIR)/src/core/include/spec/xilinx_uartps_0
 INC_DIR += $(REP_DIR)/src/core/include/spec/zynq_qemu
 
+# core.inc files use BASE_HW_DIR in order to allow 
+# including these files from other repositories
+BASE_HW_DIR := $(REP_DIR)
+
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/zynq/core.inc


### PR DESCRIPTION
All core.inc files now use $BASE_HW_DIR instead of $REP_DIR. The former
is defined by the core.mk file. This allows including core.inc files
from other repositories (e.g. genode-world) for additional platform
support.

See https://sourceforge.net/p/genode/mailman/message/35060584/