### PR TITLE
Make Muen sinfo API available to userspace components

### DIFF
--- a/repos/base-hw/include/spec/x86_64/muen/sinfo.h
+++ b/repos/base-hw/include/spec/x86_64/muen/sinfo.h
@@ -32,6 +32,8 @@ class Genode::Sinfo
 	public:
 
 		enum Config {
+			BASE_ADDR       = 0xe00000000,
+			SIZE            = 0x7000,
 			MAX_NAME_LENGTH = 63,
 		};
 

--- a/repos/base-hw/include/spec/x86_64/muen/sinfo.h
+++ b/repos/base-hw/include/spec/x86_64/muen/sinfo.h
@@ -155,6 +155,11 @@ class Genode::Sinfo
 		 */
 		uint64_t get_sched_end(void);
 
+		/*
+		 * Log sinfo status.
+		 */
+		void log_status();
+
 	private:
 
 		subject_info_type * sinfo;

--- a/repos/base-hw/include/spec/x86_64/muen/sinfo.h
+++ b/repos/base-hw/include/spec/x86_64/muen/sinfo.h
@@ -14,8 +14,8 @@
  * under the terms of the GNU General Public License version 2.
  */
 
-#ifndef _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_H_
-#define _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_H_
+#ifndef _INCLUDE__SPEC__X86_64__MUEN__SINFO_H_
+#define _INCLUDE__SPEC__X86_64__MUEN__SINFO_H_
 
 #include <base/stdint.h>
 
@@ -152,4 +152,4 @@ class Genode::Sinfo
 		static uint64_t get_sched_end(void);
 };
 
-#endif /* _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_H_ */
+#endif /* _INCLUDE__SPEC__X86_64__MUEN__SINFO_H_ */

--- a/repos/base-hw/include/spec/x86_64/muen/sinfo.h
+++ b/repos/base-hw/include/spec/x86_64/muen/sinfo.h
@@ -19,6 +19,8 @@
 
 #include <base/stdint.h>
 
+struct subject_info_type;
+
 namespace Genode
 {
 	/**
@@ -32,12 +34,12 @@ class Genode::Sinfo
 	public:
 
 		enum Config {
-			BASE_ADDR       = 0xe00000000,
-			SIZE            = 0x7000,
-			MAX_NAME_LENGTH = 63,
+			PHYSICAL_BASE_ADDR = 0xe00000000,
+			SIZE               = 0x7000,
+			MAX_NAME_LENGTH    = 63,
 		};
 
-		Sinfo();
+		Sinfo(const addr_t base_addr);
 
 		/* Structure holding information about a memory region */
 		struct Memregion_info {
@@ -72,7 +74,7 @@ class Genode::Sinfo
 		/*
 		 * Check Muen sinfo Magic.
 		 */
-		static bool check_magic(void);
+		bool check_magic(void);
 
 		/*
 		 * Return information for a channel given by name.
@@ -81,7 +83,7 @@ class Genode::Sinfo
 		 * event_number and vector parameters are only valid if indicated by
 		 * the has_[event|vector] struct members.
 		 */
-		static bool get_channel_info(const char * const name,
+		bool get_channel_info(const char * const name,
 				struct Channel_info *channel);
 
 		/*
@@ -89,7 +91,7 @@ class Genode::Sinfo
 		 *
 		 * If no memory region with given name exists, False is returned.
 		 */
-		static bool get_memregion_info(const char * const name,
+		bool get_memregion_info(const char * const name,
 				struct Memregion_info *memregion);
 
 		/*
@@ -98,7 +100,7 @@ class Genode::Sinfo
 		 * The function returns false if no device information for the
 		 * specified device exists.
 		 */
-		static bool get_dev_info(const uint16_t sid, struct Dev_info *dev);
+		bool get_dev_info(const uint16_t sid, struct Dev_info *dev);
 
 		/*
 		 * Channel callback.
@@ -116,7 +118,7 @@ class Genode::Sinfo
 		 * invocation of the callback. If a callback invocation returns false,
 		 * processing is aborted and false is returned to the caller.
 		 */
-		static bool for_each_channel(Channel_cb func, void *data);
+		bool for_each_channel(Channel_cb func, void *data);
 
 		/*
 		 * Memory region callback.
@@ -134,24 +136,43 @@ class Genode::Sinfo
 		 * invocation of the callback. If a callback invocation returns false,
 		 * processing is aborted and false is returned to the caller.
 		 */
-		static bool for_each_memregion(Memregion_cb func, void *data);
+		bool for_each_memregion(Memregion_cb func, void *data);
 
 		/*
 		 * Return TSC tick rate in kHz.
 		 *
 		 * The function returns 0 if the TSC tick rate cannot be retrieved.
 		 */
-		static uint64_t get_tsc_khz(void);
+		uint64_t get_tsc_khz(void);
 
 		/*
 		 * Return start time of current minor frame in TSC ticks.
 		 */
-		static uint64_t get_sched_start(void);
+		uint64_t get_sched_start(void);
 
 		/*
 		 * Return end time of current minor frame in TSC ticks.
 		 */
-		static uint64_t get_sched_end(void);
+		uint64_t get_sched_end(void);
+
+	private:
+
+		subject_info_type * sinfo;
+
+		/*
+		 * Fill memregion struct with memory region info from resource given by
+		 * index.
+		 */
+		void fill_memregion_data(uint8_t idx, struct Memregion_info *region);
+
+		/*
+		 * Fill channel struct with channel information from resource given by
+		 * index.
+		 */
+		void fill_channel_data(uint8_t idx, struct Channel_info *channel);
+
+		/* Fill dev struct with data from PCI device info given by index. */
+		void fill_dev_data(uint8_t idx, struct Dev_info *dev);
 };
 
 #endif /* _INCLUDE__SPEC__X86_64__MUEN__SINFO_H_ */

--- a/repos/base-hw/lib/mk/spec/muen/base-common.mk
+++ b/repos/base-hw/lib/mk/spec/muen/base-common.mk
@@ -1,0 +1,5 @@
+SRC_CC += sinfo.cc
+
+vpath %.cc $(REP_DIR)/src/base/muen
+
+include $(REP_DIR)/lib/mk/spec/x86_64/base-common.mk

--- a/repos/base-hw/lib/mk/spec/x86_64/core-muen_on.mk
+++ b/repos/base-hw/lib/mk/spec/x86_64/core-muen_on.mk
@@ -16,7 +16,6 @@ SRC_S += spec/x86_64/muen/kernel/crt0_translation_table.s
 SRC_CC += spec/x86_64/muen/kernel/cpu_exception.cc
 SRC_CC += spec/x86_64/muen/kernel/thread_exception.cc
 SRC_CC += spec/x86_64/muen/platform_support.cc
-SRC_CC += spec/x86_64/muen/sinfo.cc
 
 # include less specific configuration
 include $(REP_DIR)/lib/mk/spec/x86_64/core.inc

--- a/repos/base-hw/src/base/muen/musinfo.h
+++ b/repos/base-hw/src/base/muen/musinfo.h
@@ -11,8 +11,8 @@
  * under the terms of the GNU General Public License version 2.
  */
 
-#ifndef _CORE__SPEC__X86_64__MUEN__MUSINFO_H_
-#define _CORE__SPEC__X86_64__MUEN__MUSINFO_H_
+#ifndef _BASE__MUEN__MUSINFO_H_
+#define _BASE__MUEN__MUSINFO_H_
 
 #include <base/stdint.h>
 
@@ -82,4 +82,4 @@ struct subject_info_type {
 	struct dev_info_type dev_info[MAX_RESOURCE_COUNT];
 } __attribute__((packed, aligned (8)));
 
-#endif /* _CORE__SPEC__X86_64__MUEN__MUSINFO_H_ */
+#endif /* _BASE__MUEN__MUSINFO_H_ */

--- a/repos/base-hw/src/base/muen/musinfo.h
+++ b/repos/base-hw/src/base/muen/musinfo.h
@@ -1,7 +1,7 @@
 /*
  * \brief   Muen subject info
- * \author  Stefan Kalkowski
- * \date    2015-06-02
+ * \author  Reto Buerki
+ * \date    2015-04-21
  */
 
 /*

--- a/repos/base-hw/src/base/muen/sinfo.cc
+++ b/repos/base-hw/src/base/muen/sinfo.cc
@@ -75,13 +75,6 @@ Sinfo::Sinfo(const addr_t base_addr)
 		PERR("muen-sinfo: Subject information MAGIC mismatch\n");
 		return;
 	}
-
-	PINF("muen-sinfo: Subject information exports %d memory region(s)\n",
-	     sinfo->memregion_count);
-	for_each_memregion(log_memregion, 0);
-	PINF("muen-sinfo: Subject information exports %d channel(s)\n",
-	     sinfo->channel_info_count);
-	for_each_channel(log_channel, 0);
 }
 
 
@@ -208,6 +201,26 @@ uint64_t Sinfo::get_sched_end(void)
 		return 0;
 
 	return sinfo->tsc_schedule_end;
+}
+
+
+void Sinfo::log_status()
+{
+	if (!sinfo) {
+		PINF("Sinfo API not initialized");
+		return;
+	}
+	if (!check_magic()) {
+		PINF("Sinfo MAGIC not found");
+		return;
+	}
+
+	PINF("muen-sinfo: Subject information exports %d memory region(s)\n",
+	     sinfo->memregion_count);
+	for_each_memregion(log_memregion, 0);
+	PINF("muen-sinfo: Subject information exports %d channel(s)\n",
+	     sinfo->channel_info_count);
+	for_each_channel(log_channel, 0);
 }
 
 

--- a/repos/base-hw/src/base/muen/sinfo.cc
+++ b/repos/base-hw/src/base/muen/sinfo.cc
@@ -18,12 +18,8 @@
 
 #include "musinfo.h"
 
-enum {
-	SINFO_BASE_ADDR = 0xe00000000,
-};
-
 static const subject_info_type *
-const sinfo = ((subject_info_type *)SINFO_BASE_ADDR);
+const sinfo = ((subject_info_type *)Sinfo::BASE_ADDR);
 
 
 /* Log channel information */

--- a/repos/base-hw/src/base/muen/sinfo.cc
+++ b/repos/base-hw/src/base/muen/sinfo.cc
@@ -13,8 +13,8 @@
 
 #include <base/printf.h>
 #include <util/string.h>
-#include <board.h>
-#include <sinfo.h>
+
+#include <muen/sinfo.h>
 
 #include "musinfo.h"
 
@@ -23,7 +23,7 @@ enum {
 };
 
 static const subject_info_type *
-const sinfo = ((subject_info_type *)Board::SINFO_BASE_ADDR);
+const sinfo = ((subject_info_type *)SINFO_BASE_ADDR);
 
 
 /* Log channel information */

--- a/repos/base-hw/src/core/include/platform.h
+++ b/repos/base-hw/src/core/include/platform.h
@@ -75,6 +75,11 @@ namespace Genode {
 			 */
 			 void _init_io_mem_alloc();
 
+			 /**
+			  * Perform additional platform-specific initialization.
+			  */
+			 void _init_additional();
+
 		public:
 
 			/**

--- a/repos/base-hw/src/core/include/spec/x86/board.h
+++ b/repos/base-hw/src/core/include/spec/x86/board.h
@@ -1,5 +1,5 @@
 /*
- * \brief  x86 mmio constants
+ * \brief  x86 constants
  * \author Reto Buerki
  * \date   2015-03-18
  */

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/board.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/board.h
@@ -19,8 +19,6 @@ namespace Genode
 	struct Board
 	{
 		enum {
-			SINFO_BASE_ADDR = 0xe00000000,
-			SINFO_SIZE      = 0x7000,
 			TIMER_BASE_ADDR = 0xe00010000,
 			TIMER_SIZE      = 0x1000,
 

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/board.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/board.h
@@ -1,0 +1,36 @@
+/*
+ * \brief  x86_64_muen constants
+ * \author Adrian-Ken Rueegsegger
+ * \date   2015-07-02
+ */
+
+/*
+ * Copyright (C) 2015 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _CORE__INCLUDE__SPEC__X86_64__MUEN__BOARD_H_
+#define _CORE__INCLUDE__SPEC__X86_64__MUEN__BOARD_H_
+
+namespace Genode
+{
+	struct Board
+	{
+		enum {
+			SINFO_BASE_ADDR = 0xe00000000,
+			SINFO_SIZE      = 0x7000,
+			TIMER_BASE_ADDR = 0xe00010000,
+			TIMER_SIZE      = 0x1000,
+
+			VECTOR_REMAP_BASE   = 48,
+			TIMER_VECTOR_KERNEL = 32,
+			TIMER_VECTOR_USER   = 50,
+		};
+
+		void init() { }
+	};
+}
+
+#endif /* _CORE__INCLUDE__SPEC__X86_64__MUEN__BOARD_H_ */

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/sinfo_instance.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/sinfo_instance.h
@@ -1,0 +1,35 @@
+/*
+ * \brief  Sinfo kernel singleton
+ * \author Reto Buerki
+ * \date   2016-05-09
+ */
+
+/*
+ * Copyright (C) 2016 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU General Public License version 2.
+ */
+
+#ifndef _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_INSTANCE_H_
+#define _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_INSTANCE_H_
+
+/* base includes */
+#include <base/printf.h>
+#include <muen/sinfo.h>
+
+/* core includes */
+#include <board.h>
+
+namespace Genode
+{
+	/**
+	 * Return sinfo singleton
+	 */
+	static Sinfo * sinfo() {
+		static Sinfo singleton(Sinfo::PHYSICAL_BASE_ADDR);
+		return &singleton;
+	}
+}
+
+#endif /* _CORE__INCLUDE__SPEC__X86_64__MUEN__SINFO_INSTANCE_H_ */

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
@@ -14,12 +14,13 @@
 #ifndef _CORE__INCLUDE__SPEC__X86_64__MUEN__TIMER_H_
 #define _CORE__INCLUDE__SPEC__X86_64__MUEN__TIMER_H_
 
+/* base includes */
 #include <base/printf.h>
 #include <kernel/types.h>
+#include <muen/sinfo.h>
 
 /* core includes */
 #include <board.h>
-#include <sinfo.h>
 
 namespace Genode
 {

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
@@ -63,6 +63,10 @@ class Genode::Timer
 		Timer() :
 			_tics_per_ms(sinfo()->get_tsc_khz())
 		{
+
+			/* first sinfo instance, output status */
+			sinfo()->log_status();
+
 			struct Sinfo::Memregion_info region;
 			if (!sinfo()->get_memregion_info("timer", &region)) {
 				PERR("muen-timer: Unable to retrieve time memory region");

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
@@ -17,10 +17,10 @@
 /* base includes */
 #include <base/printf.h>
 #include <kernel/types.h>
-#include <muen/sinfo.h>
 
 /* core includes */
 #include <board.h>
+#include <sinfo_instance.h>
 
 namespace Genode
 {
@@ -37,8 +37,6 @@ class Genode::Timer
 		using time_t = Kernel::time_t;
 
 		enum { TIMER_DISABLED = ~0ULL };
-
-		Sinfo _sinfo;
 
 		uint64_t _tics_per_ms;
 
@@ -63,11 +61,10 @@ class Genode::Timer
 	public:
 
 		Timer() :
-			_sinfo(Sinfo::PHYSICAL_BASE_ADDR),
-			_tics_per_ms(_sinfo.get_tsc_khz())
+			_tics_per_ms(sinfo()->get_tsc_khz())
 		{
 			struct Sinfo::Memregion_info region;
-			if (!_sinfo.get_memregion_info("timer", &region)) {
+			if (!sinfo()->get_memregion_info("timer", &region)) {
 				PERR("muen-timer: Unable to retrieve time memory region");
 				throw Invalid_region();
 			}

--- a/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
+++ b/repos/base-hw/src/core/include/spec/x86_64/muen/timer.h
@@ -38,6 +38,8 @@ class Genode::Timer
 
 		enum { TIMER_DISABLED = ~0ULL };
 
+		Sinfo _sinfo;
+
 		uint64_t _tics_per_ms;
 
 		struct Subject_timer
@@ -47,6 +49,7 @@ class Genode::Timer
 		} __attribute__((packed));
 
 		struct Subject_timer * _timer_page;
+
 
 		inline uint64_t rdtsc()
 		{
@@ -59,10 +62,12 @@ class Genode::Timer
 
 	public:
 
-		Timer() : _tics_per_ms(Sinfo::get_tsc_khz())
+		Timer() :
+			_sinfo(Sinfo::PHYSICAL_BASE_ADDR),
+			_tics_per_ms(_sinfo.get_tsc_khz())
 		{
 			struct Sinfo::Memregion_info region;
-			if (!Sinfo::get_memregion_info("timer", &region)) {
+			if (!_sinfo.get_memregion_info("timer", &region)) {
 				PERR("muen-timer: Unable to retrieve time memory region");
 				throw Invalid_region();
 			}

--- a/repos/base-hw/src/core/platform.cc
+++ b/repos/base-hw/src/core/platform.cc
@@ -162,6 +162,8 @@ Platform::Platform()
 		_rom_fs.insert(rom_module);
 	}
 
+	_init_additional();
+
 	/* print ressource summary */
 	if (VERBOSE) {
 		printf("Core virtual memory allocator\n");

--- a/repos/base-hw/src/core/spec/arm/platform_support.cc
+++ b/repos/base-hw/src/core/spec/arm/platform_support.cc
@@ -18,6 +18,8 @@ using namespace Genode;
 
 void Platform::_init_io_port_alloc() { };
 
+void Platform::_init_additional() { };
+
 void Platform::setup_irq_mode(unsigned, unsigned, unsigned) { }
 
 Native_region * mmio_regions(unsigned);

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -106,3 +106,6 @@ Native_region * Platform::_ram_regions(unsigned const i)
 	};
 	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
 }
+
+
+void Platform::_init_additional() { }

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -16,6 +16,7 @@
 #include <util/mmio.h>
 
 /* core includes */
+#include <board.h>
 #include <platform.h>
 #include <sinfo.h>
 
@@ -61,10 +62,9 @@ Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 	static Native_region _regions[] =
 	{
 		/* Sinfo pages */
-		{ 0x000e00000000, 0x7000 },
-
+		{ Board::SINFO_BASE_ADDR, Board::SINFO_SIZE },
 		/* Timer page */
-		{ 0x000e00010000, 0x1000 },
+		{ Board::TIMER_BASE_ADDR, Board::TIMER_SIZE },
 	};
 	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
 }

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -15,10 +15,12 @@
 /* Genode includes */
 #include <util/mmio.h>
 
+/* base includes */
+#include <muen/sinfo.h>
+
 /* core includes */
 #include <board.h>
 #include <platform.h>
-#include <sinfo.h>
 
 using namespace Genode;
 

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -108,4 +108,10 @@ Native_region * Platform::_ram_regions(unsigned const i)
 }
 
 
-void Platform::_init_additional() { }
+void Platform::_init_additional()
+{
+	/* export subject info page as ROM module */
+	_rom_fs.insert(new (core_mem_alloc())
+	               Rom_module((addr_t)Board::SINFO_BASE_ADDR,
+	               Board::SINFO_SIZE, "subject_info_page"));
+}

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -64,7 +64,7 @@ Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 	static Native_region _regions[] =
 	{
 		/* Sinfo pages */
-		{ Board::SINFO_BASE_ADDR, Board::SINFO_SIZE },
+		{ Sinfo::BASE_ADDR, Sinfo::SIZE },
 		/* Timer page */
 		{ Board::TIMER_BASE_ADDR, Board::TIMER_SIZE },
 	};
@@ -114,6 +114,6 @@ void Platform::_init_additional()
 {
 	/* export subject info page as ROM module */
 	_rom_fs.insert(new (core_mem_alloc())
-	               Rom_module((addr_t)Board::SINFO_BASE_ADDR,
-	               Board::SINFO_SIZE, "subject_info_page"));
+	               Rom_module((addr_t)Sinfo::BASE_ADDR,
+	               Sinfo::SIZE, "subject_info_page"));
 }

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -64,7 +64,7 @@ Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 	static Native_region _regions[] =
 	{
 		/* Sinfo pages */
-		{ Sinfo::BASE_ADDR, Sinfo::SIZE },
+		{ Sinfo::PHYSICAL_BASE_ADDR, Sinfo::SIZE },
 		/* Timer page */
 		{ Board::TIMER_BASE_ADDR, Board::TIMER_SIZE },
 	};
@@ -80,8 +80,10 @@ bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
 {
 	const unsigned sid = Mmconf_address::to_sid(mmconf);
 
+	static Sinfo sinfo(Sinfo::PHYSICAL_BASE_ADDR);
+
 	struct Sinfo::Dev_info dev_info;
-	if (!Sinfo::get_dev_info(sid, &dev_info)) {
+	if (!sinfo.get_dev_info(sid, &dev_info)) {
 		PERR("error retrieving Muen info for device with SID 0x%x", sid);
 		return false;
 	}
@@ -114,6 +116,6 @@ void Platform::_init_additional()
 {
 	/* export subject info page as ROM module */
 	_rom_fs.insert(new (core_mem_alloc())
-	               Rom_module((addr_t)Sinfo::BASE_ADDR,
+	               Rom_module((addr_t)Sinfo::PHYSICAL_BASE_ADDR,
 	               Sinfo::SIZE, "subject_info_page"));
 }

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -15,12 +15,10 @@
 /* Genode includes */
 #include <util/mmio.h>
 
-/* base includes */
-#include <muen/sinfo.h>
-
 /* core includes */
 #include <board.h>
 #include <platform.h>
+#include <sinfo_instance.h>
 
 using namespace Genode;
 
@@ -80,10 +78,8 @@ bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
 {
 	const unsigned sid = Mmconf_address::to_sid(mmconf);
 
-	static Sinfo sinfo(Sinfo::PHYSICAL_BASE_ADDR);
-
 	struct Sinfo::Dev_info dev_info;
-	if (!sinfo.get_dev_info(sid, &dev_info)) {
+	if (!sinfo()->get_dev_info(sid, &dev_info)) {
 		PERR("error retrieving Muen info for device with SID 0x%x", sid);
 		return false;
 	}

--- a/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/platform_support.cc
@@ -100,11 +100,21 @@ bool Platform::get_msi_params(const addr_t mmconf, addr_t &address,
 
 Native_region * Platform::_ram_regions(unsigned const i)
 {
-	static Native_region _regions[] =
-	{
-		{ 25*1024*1024, 256*1024*1024 }
-	};
-	return i < sizeof(_regions)/sizeof(_regions[0]) ? &_regions[i] : 0;
+	if (i)
+		return 0;
+
+	static Native_region result = { .base = 0, .size = 0 };
+
+	if (!result.size) {
+		struct Sinfo::Memregion_info region;
+		if (!sinfo()->get_memregion_info("ram", &region)) {
+			PERR("Unable to retrieve base-hw ram region");
+			return 0;
+		}
+
+		result = { .base = region.address, .size = region.size };
+	}
+	return &result;
 }
 
 

--- a/repos/base-hw/src/core/spec/x86_64/muen/sinfo.cc
+++ b/repos/base-hw/src/core/spec/x86_64/muen/sinfo.cc
@@ -13,6 +13,7 @@
 
 #include <base/printf.h>
 #include <util/string.h>
+#include <board.h>
 #include <sinfo.h>
 
 #include "musinfo.h"
@@ -22,7 +23,7 @@ enum {
 };
 
 static const subject_info_type *
-const sinfo = ((subject_info_type *)SINFO_BASE_ADDR);
+const sinfo = ((subject_info_type *)Board::SINFO_BASE_ADDR);
 
 
 /* Log channel information */

--- a/repos/base-hw/src/core/spec/x86_64/platform_support.cc
+++ b/repos/base-hw/src/core/spec/x86_64/platform_support.cc
@@ -23,6 +23,7 @@ using namespace Genode;
 /* contains physical pointer to multiboot */
 extern "C" Genode::addr_t __initial_bx;
 
+void Platform::_init_additional() { };
 
 Native_region * Platform::_core_only_mmio_regions(unsigned const i)
 {

--- a/repos/base/include/base/output.h
+++ b/repos/base/include/base/output.h
@@ -72,6 +72,11 @@ namespace Genode {
 	void print(Output &output, unsigned long);
 
 	/**
+	 * Print unsigned long long value
+	 */
+	void print(Output &output, unsigned long long);
+
+	/**
 	 * Print unsigned integer value
 	 */
 	static inline void print(Output &output, unsigned value)

--- a/repos/base/src/lib/base/output.cc
+++ b/repos/base/src/lib/base/output.cc
@@ -58,6 +58,12 @@ void Genode::print(Output &output, unsigned long value)
 }
 
 
+void Genode::print(Output &output, unsigned long long value)
+{
+	out_unsigned<unsigned long long>(value, 10, 0, [&] (char c) { output.out_char(c); });
+}
+
+
 void Genode::print(Output &output, long value)
 {
 	out_signed<long>(value, 10, [&] (char c) { output.out_char(c); });

--- a/repos/dde_ipxe/src/drivers/nic/main.cc
+++ b/repos/dde_ipxe/src/drivers/nic/main.cc
@@ -59,7 +59,7 @@ class Ipxe_session_component  : public Nic::Session_component
 				return false;
 
 			Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}

--- a/repos/dde_linux/src/lib/usb/include/usb_nic_component.h
+++ b/repos/dde_linux/src/lib/usb/include/usb_nic_component.h
@@ -100,7 +100,7 @@ class Usb_nic::Session_component : public Nic::Session_component
 			unsigned char *ptr = nullptr;
 
 			/* submit received packets to lower layer */
-			while (((_tx.sink()->packet_avail() || save.valid()) && _tx.sink()->ready_to_ack()))
+			while (((_tx.sink()->packet_avail() || save.size()) && _tx.sink()->ready_to_ack()))
 			{
 				/* alloc skb */
 				if (!skb) {
@@ -111,7 +111,7 @@ class Usb_nic::Session_component : public Nic::Session_component
 					work_skb.data = nullptr;
 				}
 
-				Packet_descriptor packet = save.valid() ? save : _tx.sink()->get_packet();
+				Packet_descriptor packet = save.size() ? save : _tx.sink()->get_packet();
 				save                     = Packet_descriptor();
 
 				if (!_device->skb_fill(&work_skb, ptr, packet.size(), skb->end)) {
@@ -147,7 +147,7 @@ class Usb_nic::Session_component : public Nic::Session_component
 				return false;
 
 			Genode::Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}

--- a/repos/dde_linux/src/lib/wifi/nic.cc
+++ b/repos/dde_linux/src/lib/wifi/nic.cc
@@ -62,7 +62,7 @@ class Wifi_session_component : public Nic::Session_component
 				return false;
 
 			Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}

--- a/repos/dde_rump/src/server/rump_fs/directory.h
+++ b/repos/dde_rump/src/server/rump_fs/directory.h
@@ -203,6 +203,7 @@ class File_system::Directory : public Node
 			else
 				return 0;
 
+			e->inode = s.st_ino;
 			strncpy(e->name, dent->d_name, dent->d_namlen + 1);
 			return sizeof(Directory_entry);
 		}

--- a/repos/libports/src/lib/qemu-usb/host.cc
+++ b/repos/libports/src/lib/qemu-usb/host.cc
@@ -228,18 +228,9 @@ struct Usb_host_device : List<Usb_host_device>::Element
 
 	Usb::Packet_descriptor alloc_packet(int length)
 	{
+
 		if (!usb_raw.source()->ready_to_submit())
 			throw -1;
-
-		if (length <= 0) {
-			/*
-			 * XXX Packets without payload are not supported by the packet stream
-			 *     currently. Therefore, we use a (small) bogus length
-			 *     here and depend on the USB driver to handle this case
-			 *     correctly.
-			 */
-			length = 4;
-		}
 
 		Usb::Packet_descriptor packet = usb_raw.source()->alloc_packet(length);
 		packet.completion = alloc_completion();

--- a/repos/os/include/block/component.h
+++ b/repos/os/include/block/component.h
@@ -103,7 +103,7 @@ class Block::Session_component : public Block::Session_component_base,
 			_p_to_handle.succeeded(false);
 
 			/* ignore invalid packets */
-			if (!packet.valid() || !_range_check(_p_to_handle)) {
+			if (!packet.size() || !_range_check(_p_to_handle)) {
 				_ack_packet(_p_to_handle);
 				return;
 			}

--- a/repos/os/include/usb/packet_handler.h
+++ b/repos/os/include/usb/packet_handler.h
@@ -85,16 +85,6 @@ class Usb::Packet_handler
 				throw Usb::Session::Tx::Source::Packet_alloc_failed();
 			}
 
-			if (size == 0) {
-				/*
-				 * XXX Packets without payload are not supported by the packet
-				 *     stream currently. Therefore, we use a (small) bogus
-				 *     length here and depend on the USB driver to handle this
-				 *     case correctly.
-				 */
-				size = 4;
-			}
-
 			while (true) {
 				try {
 					Packet_descriptor p = _connection.source()->alloc_packet(size);

--- a/repos/os/src/drivers/ahci/ata_driver.h
+++ b/repos/os/src/drivers/ahci/ata_driver.h
@@ -198,7 +198,7 @@ struct Ata_driver : Port_driver
 	unsigned find_free_cmd_slot()
 	{
 		for (unsigned slot = 0; slot < cmd_slots; slot++)
-			if (!pending[slot].valid())
+			if (!pending[slot].size())
 				return slot;
 
 		throw Block::Driver::Request_congestion();
@@ -209,7 +209,7 @@ struct Ata_driver : Port_driver
 		unsigned slots =  Port::read<Ci>() | Port::read<Sact>();
 
 		for (unsigned slot = 0; slot < cmd_slots; slot++) {
-			if ((slots & (1U << slot)) || !pending[slot].valid())
+			if ((slots & (1U << slot)) || !pending[slot].size())
 				continue;
 
 			Block::Packet_descriptor p = pending[slot];
@@ -224,7 +224,7 @@ struct Ata_driver : Port_driver
 		Block::sector_t end = block_number + count - 1;
 
 		for (unsigned slot = 0; slot < cmd_slots; slot++) {
-			if (!pending[slot].valid())
+			if (!pending[slot].size())
 				continue;
 
 			Block::sector_t pending_start = pending[slot].block_number();

--- a/repos/os/src/drivers/ahci/atapi_driver.h
+++ b/repos/os/src/drivers/ahci/atapi_driver.h
@@ -86,7 +86,7 @@ struct Atapi_driver : Port_driver
 	{
 		unsigned slots = Port::read<Ci>();
 
-		if (slots & 1 || !pending.valid())
+		if (slots & 1 || !pending.size())
 			return;
 
 		Block::Packet_descriptor p = pending;
@@ -176,7 +176,7 @@ struct Atapi_driver : Port_driver
 	              addr_t                    phys,
 	              Block::Packet_descriptor &packet) override
 	{
-		if (pending.valid())
+		if (pending.size())
 			throw Block::Driver::Request_congestion();
 
 		sanity_check(block_number, count);

--- a/repos/os/src/drivers/nic/gem/cadence_gem.h
+++ b/repos/os/src/drivers/nic/gem/cadence_gem.h
@@ -461,7 +461,7 @@ namespace Genode
 					return false;
 
 				Genode::Packet_descriptor packet = _tx.sink()->get_packet();
-				if (!packet.valid()) {
+				if (!packet.size()) {
 					PWRN("Invalid tx packet");
 					return true;
 				}

--- a/repos/os/src/drivers/nic/spec/lan9118/lan9118.h
+++ b/repos/os/src/drivers/nic/spec/lan9118/lan9118.h
@@ -199,7 +199,7 @@ class Lan9118 : public Nic::Session_component,
 				return false;
 
 			Genode::Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}

--- a/repos/os/src/drivers/nic/spec/linux/main.cc
+++ b/repos/os/src/drivers/nic/spec/linux/main.cc
@@ -128,7 +128,7 @@ class Linux_session_component : public Nic::Session_component
 				return false;
 
 			Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}

--- a/repos/os/src/server/nic_bridge/packet_handler.cc
+++ b/repos/os/src/server/nic_bridge/packet_handler.cc
@@ -30,7 +30,7 @@ void Packet_handler::_ready_to_submit(unsigned)
 	/* as long as packets are available, and we can ack them */
 	while (sink()->packet_avail()) {
 		_packet = sink()->get_packet();
-		if (!_packet.valid()) continue;
+		if (!_packet.size()) continue;
 		handle_ethernet(sink()->packet_content(_packet), _packet.size());
 
 		if (!sink()->ready_to_ack()) {

--- a/repos/os/src/server/part_blk/component.h
+++ b/repos/os/src/server/part_blk/component.h
@@ -73,7 +73,7 @@ class Block::Session_component : public Block::Session_rpc_object,
 			_p_to_handle.succeeded(false);
 
 			/* ignore invalid packets */
-			if (!packet.valid() || !_range_check(_p_to_handle)) {
+			if (!packet.size() || !_range_check(_p_to_handle)) {
 				_ack_packet(_p_to_handle);
 				return;
 			}

--- a/repos/ports/src/app/openvpn/main.cc
+++ b/repos/ports/src/app/openvpn/main.cc
@@ -110,7 +110,7 @@ class Openvpn_component : public Tuntap_device,
 				return false;
 
 			Packet_descriptor packet = _tx.sink()->get_packet();
-			if (!packet.valid()) {
+			if (!packet.size()) {
 				PWRN("Invalid tx packet");
 				return true;
 			}


### PR DESCRIPTION
This patch set moves the Muen sinfo API from base-hw _core_ to _base-common_ to make it accessible to userspace components. This is in preparation for the upcoming support of vbox in hw_x86_64_muen.

The implementation is changed from the static functions approach to class instances with the base address of the sinfo memory region in the constructor. The sinfo region is exported as ROM module in the new platform `_init_additional()` function.

This allows userspace components to attach a ROM dataspace and construct an sinfo instance with the address returned by the `rm_session()->attach()` function.

The timer and platform support code uses a common `sinfo()` function to instantiate and access the sinfo object in the kernel.