### PR TITLE
base_hw: fix run scripts using core_test = 1

### DIFF
--- a/tool/run/boot_dir/hw
+++ b/tool/run/boot_dir/hw
@@ -146,7 +146,9 @@ proc run_boot_dir {binaries} {
 		exit -1
 	}
 	clean_boot_modules
-	exec mv [run_dir]/genode/config [run_dir]/config
+	if {[file exists "[run_dir]/genode/config"] == 1} {
+		exec mv [run_dir]/genode/config [run_dir]/config
+	}
 	exec rm -rf "[run_dir]/genode"
 
 	# offer ELF image


### PR DESCRIPTION
Without this fix, e.g. `make run/hw_test` fails with:

> mv: cannot stat 'var/run/hw_info/genode/config': No such file or directory