### PR TITLE
Fix up the generation of invocation.h in base-sel4

### DIFF
--- a/repos/base-sel4/lib/mk/spec/x86_32/platform.mk
+++ b/repos/base-sel4/lib/mk/spec/x86_32/platform.mk
@@ -88,13 +88,13 @@ $(BUILD_BASE_DIR)/include/sel4/sel4_arch/invocation.h: $(LIBSEL4_DIR)/sel4_arch_
 	$(MSG_CONVERT)$(notdir $@)
 	$(VERBOSE)mkdir -p $(dir $@)
 	$(VERBOSE)python $(LIBSEL4_DIR)/tools/invocation_header_gen.py \
-	                 --xml $< --libsel4 --dest $@
+	                 --xml $< --libsel4 --sel4_arch --dest $@
 
 $(BUILD_BASE_DIR)/include/sel4/arch/invocation.h: $(LIBSEL4_DIR)/arch_include/x86/interfaces/sel4arch.xml
 	$(MSG_CONVERT)arch/$(notdir $@)
 	$(VERBOSE)mkdir -p $(dir $@)
 	$(VERBOSE)python $(LIBSEL4_DIR)/tools/invocation_header_gen.py \
-	                 --xml $< --libsel4 --sel4_arch --dest $@
+	                 --xml $< --libsel4 --arch --dest $@
 
 SEL4_CLIENT_H_SRC := $(LIBSEL4_DIR)/sel4_arch_include/ia32/interfaces/sel4arch.xml \
                      $(LIBSEL4_DIR)/arch_include/x86/interfaces/sel4arch.xml \


### PR DESCRIPTION
Currently, the generated sel4/invocation.h, sel4/arch/invocation.h, sel4/sel4_arch/invocation.h have same header file safeguard(`__LIBSEL4_INVOCATION_H`). As a result, some definitions are missing when a source file includes these invocation.h. To fix this, we should pass correct parameters to invocation_header_gen.py(`--arch` for sel4/arch/invocation.h and `--sel4_arch` for sel4/sel4_arch/invocation.h).