### PR TITLE
Fix missing "#include<heap.h>" in hello tutorial.

### DIFF
--- a/repos/hello_tutorial/src/hello/server/main.cc
+++ b/repos/hello_tutorial/src/hello/server/main.cc
@@ -14,6 +14,7 @@
 
 #include <base/component.h>
 #include <base/log.h>
+#include <base/heap.h>
 #include <root/component.h>
 #include <hello_session/hello_session.h>
 #include <base/rpc_server.h>


### PR DESCRIPTION
A include declaration of `heap.h` is missing in hello tutorial. The type `Sliced_heap` is used in hello server.