### PR TITLE
Fixed build on Ubuntu 16.10 for x86_64.

### DIFF
--- a/repos/base-linux/lib/import/import-lx_hybrid.mk
+++ b/repos/base-linux/lib/import/import-lx_hybrid.mk
@@ -109,3 +109,8 @@ LD_CMD = c++
 
 # disable format-string security checks, which prevent non-literal format strings
 CC_OPT += -Wno-format-security
+
+# disable position-independent executables (which are enabled by default on
+# Ubuntu 16.10 or newer)
+CXX_LINK_OPT += -no-pie
+


### PR DESCRIPTION
Ubuntu provides a position independent shared object for libsdl-1.2-dev.
To appropriatly link it to Genode, the linker flag '-no-pie' had to be
added to the make file.