### PR TITLE
report_rom: add enabled() and enabled_sigh()

### DIFF
--- a/repos/os/include/os/reporter.h
+++ b/repos/os/include/os/reporter.h
@@ -120,6 +120,18 @@ class Genode::Reporter : Noncopyable
 			_conn->report.submit(length);
 		}
 
+		void enabled_sigh(Signal_context_capability cap) {
+			if (_enabled)
+				_conn->report.enabled_sigh(cap);
+		}
+
+		bool reporting_enabled() {
+			if (_enabled)
+				return _conn->report.enabled();
+			else
+				return false;
+		}
+
 		/**
 		 * XML generator targeting a reporter
 		 */

--- a/repos/os/include/report_rom/report_service.h
+++ b/repos/os/include/report_rom/report_service.h
@@ -41,6 +41,8 @@ struct Report::Session_component : Genode::Rpc_object<Session>, Rom::Writer
 
 		Rom::Module &_module;
 
+		Genode::Signal_context_capability _enabled_sigh;
+
 		bool &_verbose;
 
 		Rom::Module &_create_module(Rom::Module::Name const &name)
@@ -81,6 +83,16 @@ struct Report::Session_component : Genode::Rpc_object<Session>, Rom::Writer
 		 */
 		Genode::Session_label label() const override { return _label; }
 
+		void notify_enabled() { 
+			if (_enabled_sigh.valid())
+				Genode::Signal_transmitter(_enabled_sigh).submit();
+		}
+
+		void notify_disabled() { 
+			if (_enabled_sigh.valid())
+				Genode::Signal_transmitter(_enabled_sigh).submit();
+		}
+
 		Dataspace_capability dataspace() override { return _ds.cap(); }
 
 		void submit(size_t length) override
@@ -98,6 +110,13 @@ struct Report::Session_component : Genode::Rpc_object<Session>, Rom::Writer
 		void response_sigh(Genode::Signal_context_capability) override { }
 
 		size_t obtain_response() override { return 0; }
+
+		void enabled_sigh(Genode::Signal_context_capability cap) override
+		{
+			_enabled_sigh = cap;
+		}
+
+		bool enabled() override { return _module.has_readers(); }
 };
 
 

--- a/repos/os/include/report_session/client.h
+++ b/repos/os/include/report_session/client.h
@@ -37,6 +37,13 @@ struct Report::Session_client : Genode::Rpc_client<Session>
 
 	size_t obtain_response() override {
 		return call<Rpc_obtain_response>(); }
+
+	void enabled_sigh(Signal_context_capability cap) override {
+		call<Rpc_enabled_sigh>(cap); }
+
+	bool enabled() override {
+		return call<Rpc_enabled>();
+	}
 };
 
 #endif /* _INCLUDE__REPORT_SESSION__CLIENT_H_ */

--- a/repos/os/include/report_session/report_session.h
+++ b/repos/os/include/report_session/report_session.h
@@ -84,6 +84,18 @@ struct Report::Session : Genode::Session
 	 */
 	virtual size_t obtain_response() = 0;
 
+	/**
+	 * Install signal handler for status changes.
+	 */
+	virtual void enabled_sigh(Signal_context_capability) = 0;
+
+	/**
+	 * Query whether reporting shall be enabled.
+	 *
+	 * \return status 
+	 */
+	virtual bool enabled() = 0;
+
 
 	/*******************
 	 ** RPC interface **
@@ -93,8 +105,10 @@ struct Report::Session : Genode::Session
 	GENODE_RPC(Rpc_submit, void, submit, size_t);
 	GENODE_RPC(Rpc_response_sigh, void, response_sigh, Signal_context_capability);
 	GENODE_RPC(Rpc_obtain_response, size_t, obtain_response);
+	GENODE_RPC(Rpc_enabled_sigh, void, enabled_sigh, Signal_context_capability);
+	GENODE_RPC(Rpc_enabled, bool, enabled);
 	GENODE_RPC_INTERFACE(Rpc_dataspace, Rpc_submit, Rpc_response_sigh,
-	                     Rpc_obtain_response);
+	                     Rpc_obtain_response, Rpc_enabled_sigh, Rpc_enabled);
 };
 
 #endif /* _INCLUDE__REPORT_SESSION__REPORT_SESSION_H_ */

--- a/repos/os/run/report_rom.run
+++ b/repos/os/run/report_rom.run
@@ -57,6 +57,7 @@ compare_output_to {
 	[init -> test-report_rom] Reporter: open session
 	[init -> test-report_rom] Reporter: brightness 10
 	[init -> test-report_rom] ROM client: request brightness report
+	[init -> test-report_rom] Reporter: wait for enabled signal
 	[init -> test-report_rom]          -> <brightness brightness="10"/>
 	[init -> test-report_rom] Reporter: updated brightness to 77
 	[init -> test-report_rom] ROM client: wait for update notification

--- a/repos/os/src/server/log_report/main.cc
+++ b/repos/os/src/server/log_report/main.cc
@@ -66,6 +66,10 @@ class Report::Session_component : public Genode::Rpc_object<Session>
 		void response_sigh(Genode::Signal_context_capability) override { }
 
 		size_t obtain_response() override { return 0; }
+
+		void enabled_sigh(Genode::Signal_context_capability) override { }
+
+		bool enabled() override { return true; }
 };
 
 


### PR DESCRIPTION
This allows the reporter to detect whether any ROM session is subscribed
to the report. If not, writing and updating the report can be omitted to
spare some CPU cycles. This is also good for debugging.