### PR TITLE
os: added framebuffer driver that uses the multiboot2 framebuffer

### DIFF
--- a/repos/base-nova/include/nova/syscall-generic.h
+++ b/repos/base-nova/include/nova/syscall-generic.h
@@ -123,6 +123,16 @@ namespace Nova {
 		uint32_t const tsc_freq;    /* time-stamp counter frequency in kHz     */
 		uint32_t const bus_freq;    /* bus frequency in kHz                    */
 
+                struct fb_desc_t {
+                    uint64_t addr;
+                    uint32_t pitch;
+                    uint32_t width;
+                    uint32_t height;
+                    uint8_t bpp;
+                    uint8_t type;
+                    uint8_t reserved[2];
+                } __attribute__((packed)) fb_desc;
+
 		bool has_feature_vmx() const { return feature_flags & (1 << 1); }
 		bool has_feature_svm() const { return feature_flags & (1 << 2); }
 

--- a/repos/os/run/multiboot2_fb.run
+++ b/repos/os/run/multiboot2_fb.run
@@ -1,0 +1,277 @@
+#
+# Build
+#
+
+if {[have_spec odroid_xu]} {
+	puts "Run script does not support this platform."
+	exit 0
+}
+
+set build_components {
+	core init
+	drivers/timer
+	server/nitpicker app/pointer app/status_bar app/xray_trigger
+	server/liquid_framebuffer app/launchpad app/scout
+	test/nitpicker server/nitlog
+	drivers/input/dummy
+        drivers/framebuffer/spec/multiboot2
+	server/report_rom server/rom_filter
+}
+
+proc gpio_drv { } { if {[have_spec rpi] && [have_spec hw]}  { return hw_gpio_drv }
+                    if {[have_spec rpi] && [have_spec foc]} { return foc_gpio_drv }
+                    return gpio_drv }
+
+source ${genode_dir}/repos/base/run/platform_drv.inc
+
+lappend_if [need_usb_hid]   build_components drivers/usb
+lappend_if [have_spec gpio] build_components drivers/gpio
+
+append_platform_drv_build_components
+
+build $build_components
+
+create_boot_directory
+
+#
+# Generate config
+#
+
+append config {
+<config>
+	<parent-provides>
+		<service name="ROM"/>
+		<service name="RAM"/>
+		<service name="IRQ"/>
+		<service name="IO_MEM"/>
+		<service name="IO_PORT"/>
+		<service name="PD"/>
+		<service name="RM"/>
+		<service name="CPU"/>
+		<service name="LOG"/>
+	</parent-provides>
+	<default-route>
+		<any-service> <parent/> <any-child/> </any-service>
+	</default-route>}
+
+append_if [have_spec sdl] config {
+	<start name="fb_sdl">
+		<resource name="RAM" quantum="4M"/>
+		<provides>
+			<service name="Input"/>
+			<service name="Framebuffer"/>
+		</provides>
+	</start>}
+
+append_platform_drv_config
+
+append config {
+    <start name="fb_multiboot2">
+        <resource name="RAM" quantum="3M"/>
+        <provides>
+            <service name="Framebuffer"/>
+        </provides>
+    </start>
+}
+
+append_if [have_spec gpio] config "
+	<start name=\"[gpio_drv]\">
+		<resource name=\"RAM\" quantum=\"4M\"/>
+		<provides><service name=\"Gpio\"/></provides>
+		<config/>
+	</start>"
+
+append_if [have_spec imx53] config {
+	<start name="input_drv">
+		<resource name="RAM" quantum="1M"/>
+		<provides><service name="Input"/></provides>
+		<config/>
+	</start> }
+
+append config {
+    <start name="dummy_input_drv">
+        <resource name="RAM" quantum="1M"/>
+        <provides>
+            <service name="Input"/>
+        </provides>
+    </start>
+}
+
+append_if [need_usb_hid] config {
+	<start name="usb_drv">
+		<resource name="RAM" quantum="12M"/>
+		<provides><service name="Input"/></provides>
+		<config ehci="yes" uhci="yes" xhci="no"> <hid/> </config>
+	</start> }
+
+append config {
+	<start name="timer">
+		<resource name="RAM" quantum="1M"/>
+		<provides><service name="Timer"/></provides>
+	</start>
+
+	<start name="report_rom">
+		<resource name="RAM" quantum="1M"/>
+		<provides> <service name="Report"/> <service name="ROM"/> </provides>
+		<config>
+			<policy label="status_bar -> focus"      report="nitpicker -> focus"/>
+			<policy label="nitpicker_config -> xray" report="xray_trigger -> xray"/>
+			<policy label="xray_trigger -> hover"    report="nitpicker -> hover"/>
+		</config>
+	</start>
+
+	<start name="nitpicker_config">
+		<binary name="rom_filter"/>
+		<resource name="RAM" quantum="3M"/>
+		<provides><service name="ROM"/></provides>
+		<config>
+			<input name="xray_enabled" rom="xray" node="xray">
+				<attribute name="enabled" /> </input>
+
+			<output node="config">
+				<inline>
+					<report focus="yes" xray="yes" hover="yes" />
+					<domain name="pointer" layer="1" origin="pointer"
+					        content="client" label="no"/>
+					<domain name="panel" layer="2"
+					        content="client" label="no" hover="always"/>
+				</inline>
+				<if>
+					<has_value input="xray_enabled" value="no" />
+					<then>
+						<inline>
+							<domain name="launchpad" layer="3"
+							        content="client" label="no" hover="always" focus="click"
+							        ypos="18" height="-18" />
+							<domain name="" layer="3"
+							        content="client" label="no" hover="always" focus="click"
+							        ypos="18" height="-18" />
+						</inline>
+					</then>
+					<else>
+						<inline>
+							<domain name="launchpad" layer="3" color="#dd0000"
+							        content="tinted" label="yes" hover="focused" focus="click"
+							        ypos="18" height="-18" />
+							<domain name="" layer="3" color="#55dd34"
+							        content="tinted" label="yes" hover="focused" focus="click"
+							        ypos="18" height="-18" />
+						</inline>
+					</else>
+				</if>
+				<inline>
+					<policy label_prefix="pointer"            domain="pointer"/>
+					<policy label_prefix="status_bar"         domain="panel"/>
+					<policy label_prefix="scout -> launchpad" domain="launchpad"/>
+					<default-policy                           domain=""/>
+
+					<global-key name="KEY_SCROLLLOCK" label="xray_trigger -> input" />
+					<global-key name="KEY_F1"         label="xray_trigger -> input" />
+					<global-key name="KEY_F2"         label="xray_trigger -> input" />
+				</inline>
+			</output>
+		</config>
+		<route>
+			<service name="ROM" label="xray"> <child name="report_rom"/> </service>
+			<any-service> <parent/> </any-service>
+		</route>
+	</start>
+
+	<start name="xray_trigger">
+		<resource name="RAM" quantum="1M"/>
+		<config>
+			<press   name="KEY_F1" xray="on"/>
+			<release name="KEY_F1" xray="off"/>
+			<press   name="KEY_F2" xray="toggle"/>
+			<hover domain="panel"/>
+		</config>
+		<route>
+			<service name="Report"> <child name="report_rom"/> </service>
+			<service name="ROM" label="hover"> <child name="report_rom"/> </service>
+			<any-service> <parent/> <any-child/> </any-service>
+		</route>
+	</start>
+
+	<start name="nitpicker">
+		<resource name="RAM" quantum="3M"/>
+		<provides><service name="Nitpicker"/></provides>
+		<configfile name="nitpicker.config"/>
+		<route>
+			<service name="ROM" label="nitpicker.config">
+				<child name="nitpicker_config"/> </service>
+			<service name="Report">
+				<child name="report_rom"/> </service>
+			<any-service> <parent/> <any-child/> </any-service>
+		</route>
+	</start>
+
+	<start name="pointer">
+		<resource name="RAM" quantum="1M"/>
+	</start>
+
+	<start name="status_bar">
+		<resource name="RAM" quantum="1M"/>
+		<route>
+			<service name="ROM" label="focus"> <child name="report_rom"/> </service>
+			<any-service> <parent/> <any-child/> </any-service>
+		</route>
+	</start>
+
+	<start name="scout">
+		<resource name="RAM" quantum="64M" />
+	</start>
+</config>}
+
+install_config $config
+
+#
+# Create launchpad configuration
+#
+set launchpad_config_fd [open "bin/launchpad.config" w]
+puts $launchpad_config_fd {<config>
+	<launcher name="testnit"   ram_quota="768K" />
+	<launcher name="scout"     ram_quota="41M" />
+	<launcher name="launchpad" ram_quota="6M">
+		<configfile name="launchpad.config" />
+	</launcher>
+	<launcher name="nitlog"    ram_quota="1M" />
+	<launcher name="liquid_fb" ram_quota="7M">
+		<config resize_handle="on" />
+	</launcher>
+	<launcher name="nitpicker" ram_quota="3M">
+		<config>
+			<domain name="" layer="3" conten="client" label="no" focus="click"/>
+			<default-policy domain="" />
+		</config>
+	</launcher>
+</config>}
+close $launchpad_config_fd
+
+
+#
+# Boot modules
+#
+
+# generic modules
+set boot_modules {
+	core ld.lib.so init
+	timer
+	nitpicker pointer status_bar report_rom rom_filter xray_trigger
+	liquid_fb launchpad scout testnit nitlog
+	launchpad.config
+        fb_multiboot2 dummy_input_drv
+}
+
+# platform-specific modules
+lappend_if [have_spec linux]       boot_modules fb_sdl
+lappend_if [need_usb_hid]          boot_modules usb_drv
+lappend_if [have_spec gpio]        boot_modules [gpio_drv]
+lappend_if [have_spec imx53]       boot_modules input_drv
+
+append_platform_drv_boot_modules
+
+build_boot_image $boot_modules
+
+append qemu_args " -m 256 "
+
+run_genode_until forever

--- a/repos/os/src/drivers/framebuffer/spec/multiboot2/framebuffer.cc
+++ b/repos/os/src/drivers/framebuffer/spec/multiboot2/framebuffer.cc
@@ -1,0 +1,67 @@
+
+#include <framebuffer.h>
+
+using namespace Framebuffer;
+
+Session_component::Session_component(Genode::Env &i_env, void* hip_rom) : env(i_env)
+{
+    Genode::log("Initializing Multiboot2 framebuffer");
+    
+    Nova::Hip *hip = reinterpret_cast<Nova::Hip*>(hip_rom);
+
+    mbi_fb = *(struct fb_desc*)(void*)&hip->fb_desc;
+
+    if(!mbi_fb.addr){
+        Genode::error("Invalid framebuffer address");
+        throw Missing_multiboot2_fb();
+    }
+
+    Genode::log("Framebuffer with ", mbi_fb.width, "x", mbi_fb.height, "x", mbi_fb.bpp, " @ ", (void*)mbi_fb.addr);
+
+    fb_mem.construct(
+        env,
+        mbi_fb.addr,
+        mbi_fb.width * mbi_fb.height * mbi_fb.bpp / 4,
+        true);
+
+    fb_mode = Mode(mbi_fb.width, mbi_fb.height, Mode::RGB565);
+
+    fb_ram.construct(
+        env.ram(),
+        env.rm(),
+        mbi_fb.width * mbi_fb.height * fb_mode.bytes_per_pixel());
+}
+
+Mode Session_component::mode() const
+{
+    return fb_mode;
+}
+
+void Session_component::mode_sigh(Genode::Signal_context_capability _scc){};
+
+void Session_component::sync_sigh(Genode::Signal_context_capability scc){
+    timer.sigh(scc);
+    timer.trigger_periodic(10*1000);
+};
+
+void Session_component::refresh(int x, int y, int w, int h){
+    Genode::uint32_t u_x = (Genode::uint32_t)Genode::min(mbi_fb.width,  (Genode::uint32_t)Genode::max(x, 0));
+    Genode::uint32_t u_y = (Genode::uint32_t)Genode::min(mbi_fb.height, (Genode::uint32_t)Genode::max(y, 0));
+    Genode::uint32_t u_w = (Genode::uint32_t)Genode::min(mbi_fb.width,  (Genode::uint32_t)Genode::max(w, 0) + u_x);
+    Genode::uint32_t u_h = (Genode::uint32_t)Genode::min(mbi_fb.height, (Genode::uint32_t)Genode::max(h, 0) + u_y);
+    Pixel::RGBA8888 *pixel_32 = fb_mem->local_addr<Pixel::RGBA8888>();
+    Pixel::RGB565 *pixel_16 = fb_ram->local_addr<Pixel::RGB565>();
+    for(Genode::uint32_t r = u_y; r < u_h; ++r){
+        for(Genode::uint32_t c = u_x; c < u_w; ++c){
+            Session_component::rgb565_to_rgba8888(
+                    &pixel_16[c + r * mbi_fb.width],
+                    &pixel_32[c + r * mbi_fb.width]
+                    );
+        }
+    }
+}
+
+Genode::Dataspace_capability Session_component::dataspace()
+{
+    return fb_ram->cap();
+}

--- a/repos/os/src/drivers/framebuffer/spec/multiboot2/include/framebuffer.h
+++ b/repos/os/src/drivers/framebuffer/spec/multiboot2/include/framebuffer.h
@@ -1,0 +1,76 @@
+
+#pragma once
+
+#include <base/component.h>
+#include <framebuffer_session/framebuffer_session.h>
+#include <base/attached_io_mem_dataspace.h>
+#include <base/attached_ram_dataspace.h>
+#include <nova/syscalls.h>
+#include <base/signal.h>
+#include <util/reconstructible.h>
+#include <timer_session/connection.h>
+
+class Missing_multiboot2_fb : Genode::Exception {};
+
+namespace Framebuffer {
+    class Session_component;
+}
+
+namespace Pixel {
+    struct RGB565;
+    struct RGBA8888;
+}
+
+struct Pixel::RGB565
+{
+    Genode::uint8_t red : 5;
+    Genode::uint8_t green : 6;
+    Genode::uint8_t blue : 5;
+} __attribute__((packed));
+
+struct Pixel::RGBA8888
+{
+    Genode::uint8_t red;
+    Genode::uint8_t green;
+    Genode::uint8_t blue;
+    Genode::uint8_t alpha;
+} __attribute__((packed));
+
+class Framebuffer::Session_component : public Genode::Rpc_object<Framebuffer::Session>
+{
+    private:
+
+        Genode::Env &env;
+
+        struct fb_desc {
+            Genode::uint64_t addr;
+            Genode::uint32_t pitch;
+            Genode::uint32_t width;
+            Genode::uint32_t height;
+            Genode::uint8_t bpp;
+            Genode::uint8_t type;
+        } mbi_fb;
+        
+        Mode fb_mode;
+
+        Genode::Constructible<Genode::Attached_io_mem_dataspace> fb_mem;
+        Genode::Constructible<Genode::Attached_ram_dataspace> fb_ram;
+
+        Timer::Connection timer { env };
+
+        static inline void rgb565_to_rgba8888(Pixel::RGB565 *src, Pixel::RGBA8888 *dst)
+        {
+            dst->alpha = 0;
+            dst->red = (src->red * 527 + 23) >> 6;
+            dst->green = (src->green * 259 + 33) >> 6;
+            dst->blue = (src->blue * 527 + 23) >> 6;
+        }
+
+    public:
+        Session_component(Genode::Env &, void*); 
+        Mode mode() const override;
+        void mode_sigh(Genode::Signal_context_capability) override;
+        void sync_sigh(Genode::Signal_context_capability) override;
+        void refresh(int, int, int, int) override;
+        Genode::Dataspace_capability dataspace() override;
+};

--- a/repos/os/src/drivers/framebuffer/spec/multiboot2/main.cc
+++ b/repos/os/src/drivers/framebuffer/spec/multiboot2/main.cc
@@ -1,0 +1,35 @@
+
+#include <base/component.h>
+#include <base/attached_rom_dataspace.h>
+#include <dataspace/capability.h>
+#include <os/static_root.h>
+
+#include <framebuffer.h>
+
+struct Main {
+
+    Genode::Env &env;
+    
+    Genode::Attached_rom_dataspace rom_hip {
+        env,
+        "hypervisor_info_page"
+    };
+
+    Framebuffer::Session_component fb {
+        env,
+        rom_hip.local_addr<void>(),
+    };
+
+    Genode::Static_root<Framebuffer::Session> fb_root {env.ep().manage(fb)};
+
+    Main(Genode::Env &env) : env(env)
+    {
+        env.parent().announce(env.ep().manage(fb_root));
+    }
+};
+
+void Component::construct(Genode::Env &env){
+
+    static Main inst(env);
+
+}

--- a/repos/os/src/drivers/framebuffer/spec/multiboot2/target.mk
+++ b/repos/os/src/drivers/framebuffer/spec/multiboot2/target.mk
@@ -1,0 +1,5 @@
+TARGET = fb_multiboot2
+LIBS = base
+REQUIRES = nova
+SRC_CC = main.cc framebuffer.cc
+INC_DIR += $(PRG_DIR)/include


### PR DESCRIPTION
I implemented a framebuffer service that uses the framebuffer provided by multiboot2. This PR just contains the driver for Genode. Since it requires an adapted hypervisor information page, it needs a patched NOVA. As it wasn't possible to add the additional fields at the end of the hip, other configuration also might need the new NOVA.
The patched NOVA can be found at https://github.com/jklmnn/NOVA/commit/07da624bf12e964389ed4bf6d1a507272876bc46 or when https://github.com/alex-ab/NOVA/pull/2 gets merged.

Furthermore it requires the changes proposed in #2242 (https://github.com/alex-ab/genode/tree/issue_2242). Since the Grub2 used here is insufficient to provide a framebuffer, you can cherry pick https://github.com/jklmnn/genode/commit/172e084f7f1fa5e2e5f9e86a62f8c38909e4993f that adds a grub with the `efi_uga` and `efi_gop` modules. It also increases the efi image size to fit the new grub.