### PR TITLE
Do not NULL-terminate readlink result

### DIFF
--- a/repos/os/src/lib/vfs/fs_file_system.h
+++ b/repos/os/src/lib/vfs/fs_file_system.h
@@ -477,7 +477,7 @@ class Vfs::Fs_file_system : public File_system
 				    _fs.symlink(dir_handle, symlink_name.base() + 1, false);
 				Fs_handle_guard symlink_guard(*this, _fs, symlink_handle, _handle_space);
 
-				out_len = _read(symlink_guard, buf, buf_size, 0);
+				out_len = _read(symlink_guard, buf, buf_size, 0) - 1;
 
 				return READLINK_OK;
 			}


### PR DESCRIPTION
The readlink() implementation of Genodes VFS returns the link target as NULL-terminated string. Nothing in POSIX excludes this behavior, but the informative section on readlink in POSIX.1-2008 explicitly mentions that the NULL-termination can be omited:

> Conforming applications should not assume that the returned contents of the symbolic link are null-terminated.

Most implementations seem to actually omit it:

> The readlink() system call does not append a NUL character to	buf. (FreeBSD 11)
> Readlink does not append a NUL character to buf. (Darwin)
> readlink() does not append a null byte to buf. (Linux)

As the Android test cases I'm examining in fact test for the *absence* of a trailing NULL character, there may be well cases where this behavior is assumed. Hence, I suggest to drop the trailing NULL in Genodes VFS implementation for better compatibility.

Note, that I deliberately left the NULL character in the result, but just decremented the returned result length to mitigate unsafe uses of strlen() and friends. 