### PR TITLE
base-linux: Log error message for too long files

### DIFF
--- a/repos/base-linux/src/core/dataspace_component.cc
+++ b/repos/base-linux/src/core/dataspace_component.cc
@@ -35,6 +35,12 @@ Linux_dataspace::Filename Dataspace_component::_file_name(const char *args)
 {
 	Session_label const label = label_from_args(args);
 	Linux_dataspace::Filename fname;
+
+	if (label.last_element().length() > sizeof(fname.buf)) {
+		Genode::error("File name too long: ", label.last_element());
+		throw Service_denied();
+	}
+
 	strncpy(fname.buf, label.last_element().string(), sizeof(fname.buf));
 
 	/* only files inside the current working directory are allowed */


### PR DESCRIPTION
The filename buffer of a dataspace in base-linux is limited to
40 bytes. When using file names longer than this, the remainder
gets dropped silently. Add an error message to aid debugging this
case.