### PR TITLE
os: fix fb_boot_drv framebuffer padding

### DIFF
--- a/repos/os/src/drivers/framebuffer/boot/framebuffer.cc
+++ b/repos/os/src/drivers/framebuffer/boot/framebuffer.cc
@@ -35,10 +35,13 @@ Session_component::Session_component(Genode::Env &env,
 	Genode::log("Framebuffer with ", _core_fb.width, "x", _core_fb.height,
 	            "x", _core_fb.bpp, " @ ", (void*)_core_fb.addr);
 
+	/*Calculate required padding to align framebuffer to 16 pixels.*/
+	_pad = (16 - (_core_fb.width % 16)) & 0x0f;
+
 	_fb_mem.construct(
 		_env,
 		_core_fb.addr,
-		_core_fb.width * _core_fb.height * _core_fb.bpp / 4,
+		(_core_fb.width + _pad) * _core_fb.height * _core_fb.bpp / 4,
 		true);
 
 	_fb_mode = Mode(_core_fb.width, _core_fb.height, Mode::RGB565);
@@ -67,11 +70,12 @@ void Session_component::refresh(int x, int y, int w, int h)
 	Genode::Pixel_rgb565 *pixel_16 = _fb_ram->local_addr<Genode::Pixel_rgb565>();
 	for (Genode::uint32_t r = u_y; r < u_h; ++r){
 		for (Genode::uint32_t c = u_x; c < u_w; ++c){
-			Genode::uint32_t i = c + r * _core_fb.width;
-			pixel_32[i].rgba(
-				pixel_16[i].r(),
-				pixel_16[i].g(),
-				pixel_16[i].b(),
+			Genode::uint32_t s = c + r * _core_fb.width;
+			Genode::uint32_t d = c + r * (_core_fb.width + _pad);
+			pixel_32[d].rgba(
+				pixel_16[s].r(),
+				pixel_16[s].g(),
+				pixel_16[s].b(),
 				0);
 		}
 	}

--- a/repos/os/src/drivers/framebuffer/boot/include/framebuffer.h
+++ b/repos/os/src/drivers/framebuffer/boot/include/framebuffer.h
@@ -50,6 +50,8 @@ class Framebuffer::Session_component : public Genode::Rpc_object<Framebuffer::Se
 
 		Timer::Connection timer { _env };
 
+		Genode::uint8_t _pad;
+
 	public:
 		Session_component(Genode::Env &, Genode::Xml_node);
 		Mode mode() const override;


### PR DESCRIPTION
The uefi framebuffer aligns its memory range to 16 pixels. This isn't a problem for devices with a resolution width divisible by 16. But on certain resolutions (e.g. 1366x768) a line in the framebuffer is longer than a line on the screen (in this case it is 1376 pixels long). In this case the framebuffer needs to pad the additional memory to prevent a distorted output.

This patch fixes the padding for the boot framebuffer driver.