### PR TITLE
qt5: added creation of QPlatformInputContext to QNitpickerIntegration

### DIFF
--- a/repos/libports/src/lib/qt5/qtbase/src/plugins/platforms/nitpicker/qnitpickerintegration.cpp
+++ b/repos/libports/src/lib/qt5/qtbase/src/plugins/platforms/nitpicker/qnitpickerintegration.cpp
@@ -13,6 +13,8 @@
 
 /* Qt includes */
 #include <QtGui/private/qguiapplication_p.h>
+#include <qpa/qplatforminputcontextfactory_p.h>
+
 #include "qgenodeclipboard.h"
 #include "qnitpickerglcontext.h"
 #include "qnitpickerintegration.h"
@@ -82,6 +84,11 @@ QAbstractEventDispatcher *QNitpickerIntegration::createEventDispatcher() const
 void QNitpickerIntegration::initialize()
 {
     screenAdded(_nitpicker_screen);
+
+    QString icStr = QPlatformInputContextFactory::requested();
+    if (icStr.isNull())
+        icStr = QLatin1String("compose");
+    m_inputContext.reset(QPlatformInputContextFactory::create(icStr));
 }
 
 
@@ -104,6 +111,11 @@ QPlatformClipboard *QNitpickerIntegration::clipboard() const
 QPlatformOpenGLContext *QNitpickerIntegration::createPlatformOpenGLContext(QOpenGLContext *context) const
 {
     return new QNitpickerGLContext(context);
+}
+
+QPlatformInputContext *QNitpickerIntegration::inputContext() const
+{
+    return m_inputContext.data();
 }
 
 QT_END_NAMESPACE

--- a/repos/libports/src/lib/qt5/qtbase/src/plugins/platforms/nitpicker/qnitpickerintegration.h
+++ b/repos/libports/src/lib/qt5/qtbase/src/plugins/platforms/nitpicker/qnitpickerintegration.h
@@ -19,6 +19,7 @@
 
 #include <qpa/qplatformintegration.h>
 #include <qpa/qplatformscreen.h>
+#include <qpa/qplatforminputcontext.h>
 
 #include "qnitpickerscreen.h"
 #include "qsignalhandlerthread.h"
@@ -42,6 +43,7 @@ class QNitpickerIntegration : public QPlatformIntegration
 		 * variable of QNitpickerIntegration.
 		 */
 		static Genode::Signal_receiver &_signal_receiver();
+                QScopedPointer<QPlatformInputContext> m_inputContext;
 
 	public:
 
@@ -61,6 +63,8 @@ class QNitpickerIntegration : public QPlatformIntegration
 		QPlatformClipboard *clipboard() const Q_DECL_OVERRIDE;
 #endif
 		QPlatformOpenGLContext *createPlatformOpenGLContext(QOpenGLContext *context) const Q_DECL_OVERRIDE;
+
+                QPlatformInputContext *inputContext() const Q_DECL_OVERRIDE;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
This change enables the QNitpickerIntegration to dynamically load QPlatformInputContext plugins (such as the qtvirtualkeyboard plugin).