### PR TITLE
test/libc_ffat: Test ftruncate on unlinked file

### DIFF
--- a/repos/libports/src/test/libc_vfs/main.cc
+++ b/repos/libports/src/test/libc_vfs/main.cc
@@ -260,7 +260,7 @@ static void test(Genode::Xml_node node)
 		CALL_AND_CHECK(ret, close(fd), ret == 0, "");
 
 		/* test 'O_TRUNC' flag */
-		CALL_AND_CHECK(fd, open(file_name4, O_WRONLY | O_TRUNC), fd >= 0, "file_name=%s", file_name4);
+		CALL_AND_CHECK(fd, open(file_name4, O_CREAT | O_WRONLY | O_TRUNC), fd >= 0, "file_name=%s", file_name4);
 		CALL_AND_CHECK(ret, close(fd), ret == 0, "");
 		CALL_AND_CHECK(ret, stat(file_name4, &stat_buf),
 					   (ret == 0) && (stat_buf.st_size == 0),

--- a/repos/libports/src/test/libc_vfs/main.cc
+++ b/repos/libports/src/test/libc_vfs/main.cc
@@ -251,6 +251,14 @@ static void test(Genode::Xml_node node)
 					   (ret == 0) && (stat_buf.st_size == 10),
 					   "file_name=%s", file_name4);
 
+		CALL_AND_CHECK(fd, open(file_name4, O_CREAT | O_WRONLY), fd >= 0, "file_name=%s", file_name4);
+		CALL_AND_CHECK(ret, unlink(file_name4), ret == 0, "");
+		CALL_AND_CHECK(ret, ftruncate(fd, 42), ret == 0, ""); /* on unlinked file */
+		CALL_AND_CHECK(ret, fstat(fd, &stat_buf),
+					   (ret == 0) && (stat_buf.st_size == 42),
+					   "file_name=%s", file_name4);
+		CALL_AND_CHECK(ret, close(fd), ret == 0, "");
+
 		/* test 'O_TRUNC' flag */
 		CALL_AND_CHECK(fd, open(file_name4, O_WRONLY | O_TRUNC), fd >= 0, "file_name=%s", file_name4);
 		CALL_AND_CHECK(ret, close(fd), ret == 0, "");


### PR DESCRIPTION
This amends the libc_vfs test with a case that crashes ram_fs in my setup:

```
[init -> test-libc_vfs] calling ftruncate(fd, 42)
no RM attachment (READ pf_addr=0x0 pf_ip=0x0 from pager_object: pd='init -> ram_fs' thread='ep')
page fault, pd='init -> ram_fs' thread='ep' cpu=0 ip=0x0 address=0x0 stack pointer=0xa04fef18 qualifiers=0x4 irUwp reason=1
Error: Test execution timed out
```
I tested this on x86_64 (base-nova as well as base-linux).

The issue arises when unlinking the file behind an *opened* fd and then performing an ftruncate() on it. The expected behavior is a properly resized file accessible by the fd.