### PR TITLE
acpica: introduced work around to fix shutdown for HP840 machines

### DIFF
--- a/repos/libports/src/lib/acpica/osl.cc
+++ b/repos/libports/src/lib/acpica/osl.cc
@@ -266,7 +266,10 @@ UINT64 AcpiOsGetTimer (void)
 	FAIL(0)
 
 void AcpiOsStall (UINT32)
-	FAIL()
+{
+//	FAIL()
+	Genode::error(__func__, " ");
+}
 
 ACPI_STATUS AcpiOsReadMemory (ACPI_PHYSICAL_ADDRESS, UINT64 *, UINT32)
 	FAIL(AE_BAD_PARAMETER)


### PR DESCRIPTION
HP840 machines (g2/g3) call the unimplemented AcpiOsStall callback
during software shutdown. This drives acpica into an infinite loop which
prevents the shutdown. Instead, it is better to print an error message and 
continue.