### PR TITLE
base: separate toolchain and architecture

### DIFF
--- a/repos/base/etc/tools.conf
+++ b/repos/base/etc/tools.conf
@@ -18,18 +18,23 @@
 # We handle all architectures that may be specified as SPEC argument to the
 # package build tool.
 #
+
+TOOLCHAIN_PREFIX ?= /usr/local/genode-gcc/bin/genode-
+
 ifeq ($(filter-out $(SPECS),x86_32),)
-CROSS_DEV_PREFIX ?= /usr/local/genode-gcc/bin/genode-x86-
+TOOLCHAIN_ARCH ?= x86-
 endif
 ifeq ($(filter-out $(SPECS),x86_64),)
-CROSS_DEV_PREFIX ?= /usr/local/genode-gcc/bin/genode-x86-
+TOOLCHAIN_ARCH ?= x86-
 endif
 ifeq ($(filter-out $(SPECS),arm),)
-CROSS_DEV_PREFIX ?= /usr/local/genode-gcc/bin/genode-arm-
+TOOLCHAIN_ARCH ?= arm-
 endif
 ifeq ($(filter-out $(SPECS),riscv),)
-CROSS_DEV_PREFIX ?= /usr/local/genode-gcc/bin/genode-riscv-
+TOOLCHAIN_ARCH ?= riscv-
 endif
+
+CROSS_DEV_PREFIX ?= $(TOOLCHAIN_PREFIX)$(TOOLCHAIN_ARCH)
 
 #
 # We use libsupc++ from g++ version 3 because


### PR DESCRIPTION
This commit separates the `CROSS_DEV_PREFIX` into a toolchain and an architecture specific part. This makes it possible to use a custom toolchain in etc/tools.conf by overwriting `TOOLCHAIN_PREFIX` without the need to check for all architectures.
This is backwards compatible to it should not break any custom values of `CROSS_DEV_PREFIX`.