### PR TITLE
base-hw: enable SMP support for Zynq-7000 boards

### DIFF
--- a/repos/base-hw/lib/mk/spec/zynq_qemu/bootstrap-hw.mk
+++ b/repos/base-hw/lib/mk/spec/zynq_qemu/bootstrap-hw.mk
@@ -5,8 +5,10 @@ SRC_S   += bootstrap/spec/arm/crt0.s
 SRC_CC  += bootstrap/spec/arm/cpu.cc
 SRC_CC  += bootstrap/spec/arm/cortex_a9_mmu.cc
 SRC_CC  += bootstrap/spec/arm/pic.cc
-SRC_CC  += bootstrap/spec/zynq_qemu/platform.cc
+SRC_CC  += bootstrap/spec/zynq/platform.cc
 SRC_CC  += hw/spec/arm/arm_v7_cpu.cc
 SRC_CC  += hw/spec/32bit/memory_map.cc
+
+NR_OF_CPUS = 1
 
 include $(BASE_DIR)/../base-hw/lib/mk/bootstrap-hw.inc

--- a/repos/base-hw/src/bootstrap/spec/arm/cortex_a9_actlr.h
+++ b/repos/base-hw/src/bootstrap/spec/arm/cortex_a9_actlr.h
@@ -28,6 +28,13 @@ struct Bootstrap::Actlr : Bootstrap::Cpu::Actlr
 		Smp::set(v, 1);
 		write(v);
 	}
+
+	static void disable_smp()
+	{
+		auto v = read();
+		Smp::set(v, 0);
+		write(v);
+	}
 };
 
 #endif /* _SRC__BOOTSTRAP__SPEC__ARM__CORTEX_A9_ACTLR_H_ */

--- a/repos/base-hw/src/bootstrap/spec/arm/cortex_a9_mmu.cc
+++ b/repos/base-hw/src/bootstrap/spec/arm/cortex_a9_mmu.cc
@@ -109,6 +109,7 @@ unsigned Bootstrap::Platform::enable_mmu()
 
 	Cpu::Sctlr::init();
 	Cpu::Cpsr::init();
+	Actlr::disable_smp();
 
 	/* locally initialize interrupt controller */
 	pic.init_cpu_local();

--- a/repos/base-hw/src/bootstrap/spec/arm/cpu.cc
+++ b/repos/base-hw/src/bootstrap/spec/arm/cpu.cc
@@ -27,12 +27,10 @@ void Bootstrap::Cpu::enable_mmu_and_caches(Genode::addr_t table)
 	Ttbcr::write(1);
 
 	Ttbr::access_t ttbr = Ttbr::Ba::masked(table);
-	Ttbr::Rgn::set(ttbr, Ttbr::CACHEABLE);
-	if (Mpidr::read()) { /* check for SMP system */
-		Ttbr::Irgn::set(ttbr, Ttbr::CACHEABLE);
-		Ttbr::S::set(ttbr, 1);
-	} else
-		Ttbr::C::set(ttbr, 1);
+	Ttbr::Rgn::set(ttbr, Ttbr::BACK_NOALLOCATE);
+	Ttbr::Irgn::set(ttbr, Ttbr::BACK_NOALLOCATE);
+	Ttbr::S::set(ttbr, 1);
+	Ttbr::C::set(ttbr, 1);
 	Ttbr0::write(ttbr);
 	Ttbr1::write(ttbr);
 

--- a/repos/base-hw/src/bootstrap/spec/arm/cpu.cc
+++ b/repos/base-hw/src/bootstrap/spec/arm/cpu.cc
@@ -27,10 +27,17 @@ void Bootstrap::Cpu::enable_mmu_and_caches(Genode::addr_t table)
 	Ttbcr::write(1);
 
 	Ttbr::access_t ttbr = Ttbr::Ba::masked(table);
-	Ttbr::Rgn::set(ttbr, Ttbr::BACK_NOALLOCATE);
-	Ttbr::Irgn::set(ttbr, Ttbr::BACK_NOALLOCATE);
-	Ttbr::S::set(ttbr, 1);
-	Ttbr::C::set(ttbr, 1);
+
+	if (Mpidr::Me::get(Mpidr::read())) {
+		/* for coherence, memory must be marked as write-back (cf. Cortex-A9 MPcore) */
+		Ttbr::Rgn::set(ttbr, Ttbr::BACK_ALLOCATE);
+		Ttbr::Irgn::set(ttbr, Ttbr::BACK_ALLOCATE);
+		Ttbr::S::set(ttbr, 1);
+	}
+	else {
+		Ttbr::C::set(ttbr, 1);
+	}
+
 	Ttbr0::write(ttbr);
 	Ttbr1::write(ttbr);
 

--- a/repos/base-hw/src/core/kernel/init.cc
+++ b/repos/base-hw/src/core/kernel/init.cc
@@ -46,7 +46,7 @@ extern "C" void kernel_init()
 	if (Cpu::executing_id()) while (!initialized) ;
 	else {
 		Genode::log("");
-		Genode::log("kernel initialized");
+		Genode::log("kernel initialized with ", NR_OF_CPUS, " CPUs");
 	}
 
 	/* initialize cpu pool */

--- a/repos/base-hw/src/core/spec/arm/cpu_support.h
+++ b/repos/base-hw/src/core/spec/arm/cpu_support.h
@@ -42,7 +42,7 @@ struct Genode::Arm_cpu : public Hw::Arm_cpu
 	 */
 	struct Ttbr0 : Hw::Arm_cpu::Ttbr0
 	{
-		enum Memory_region { NON_CACHEABLE = 0, CACHEABLE = 1 };
+		enum Memory_region { NON_CACHEABLE = 0, CACHEABLE = 1, BACK_ALLOCATE = 1, THROUGH = 2, BACK_NOALLOCATE = 3 };
 
 		/**
 		 * Return initialized value
@@ -52,9 +52,9 @@ struct Genode::Arm_cpu : public Hw::Arm_cpu
 		static access_t init(addr_t const table)
 		{
 			access_t v = Ttbr::Ba::masked((addr_t)table);
-			Ttbr::Rgn::set(v, CACHEABLE);
+			Ttbr::Rgn::set(v, BACK_NOALLOCATE);
 			Ttbr::S::set(v, Board::SMP ? 1 : 0);
-			if (Board::SMP) Ttbr::Irgn::set(v, CACHEABLE);
+			if (Board::SMP) Ttbr::Irgn::set(v, BACK_NOALLOCATE);
 			else Ttbr::C::set(v, 1);
 			return v;
 		}

--- a/repos/base-hw/src/core/spec/arm/cpu_support.h
+++ b/repos/base-hw/src/core/spec/arm/cpu_support.h
@@ -42,8 +42,6 @@ struct Genode::Arm_cpu : public Hw::Arm_cpu
 	 */
 	struct Ttbr0 : Hw::Arm_cpu::Ttbr0
 	{
-		enum Memory_region { NON_CACHEABLE = 0, CACHEABLE = 1, BACK_ALLOCATE = 1, THROUGH = 2, BACK_NOALLOCATE = 3 };
-
 		/**
 		 * Return initialized value
 		 *
@@ -52,9 +50,9 @@ struct Genode::Arm_cpu : public Hw::Arm_cpu
 		static access_t init(addr_t const table)
 		{
 			access_t v = Ttbr::Ba::masked((addr_t)table);
-			Ttbr::Rgn::set(v, BACK_NOALLOCATE);
+			Ttbr::Rgn::set(v, Ttbr::BACK_ALLOCATE);
 			Ttbr::S::set(v, Board::SMP ? 1 : 0);
-			if (Board::SMP) Ttbr::Irgn::set(v, BACK_NOALLOCATE);
+			if (Board::SMP) Ttbr::Irgn::set(v, Ttbr::BACK_ALLOCATE);
 			else Ttbr::C::set(v, 1);
 			return v;
 		}

--- a/repos/base-hw/src/lib/hw/spec/arm/cpu.h
+++ b/repos/base-hw/src/lib/hw/spec/arm/cpu.h
@@ -90,7 +90,7 @@ struct Hw::Arm_cpu
 	 */
 	struct Ttbr : Genode::Register<32>
 	{
-		enum Memory_region { NON_CACHEABLE = 0, CACHEABLE = 1 };
+		enum Memory_region { NON_CACHEABLE = 0, CACHEABLE = 1, BACK_ALLOCATE = 1, THROUGH = 2, BACK_NOALLOCATE = 3 };
 
 		struct C   : Bitfield<0,1> { };    /* inner cacheable */
 		struct S   : Bitfield<1,1> { };    /* shareable */
@@ -105,7 +105,7 @@ struct Hw::Arm_cpu
 
 		struct Irgn_1 : Bitfield<0,1> { };
 		struct Irgn_0 : Bitfield<6,1> { };
-		struct Irgn : Genode::Bitset_2<Irgn_0, Irgn_1> { }; /* inner cache mode */
+		struct Irgn : Genode::Bitset_2<Irgn_1, Irgn_0> { }; /* inner cache mode */
 	};
 
 	struct Ttbr_64bit : Genode::Register<64>

--- a/repos/base-hw/src/lib/hw/spec/arm/cpu.h
+++ b/repos/base-hw/src/lib/hw/spec/arm/cpu.h
@@ -32,7 +32,8 @@ struct Hw::Arm_cpu
 
 	/* Multiprocessor Affinity Register */
 	ARM_CP15_REGISTER_32BIT(Mpidr, c0, c0, 0, 5,
-		struct Aff_0 : Bitfield<0, 8> { }; /* affinity value 0 */
+		struct Aff_0 : Bitfield<0, 8> { };  /* affinity value 0 */
+		struct Me    : Bitfield<31, 1> { }; /* multiprocessing extension */
 	);
 
 	/* System Control Register */
@@ -105,7 +106,7 @@ struct Hw::Arm_cpu
 
 		struct Irgn_1 : Bitfield<0,1> { };
 		struct Irgn_0 : Bitfield<6,1> { };
-		struct Irgn : Genode::Bitset_2<Irgn_1, Irgn_0> { }; /* inner cache mode */
+		struct Irgn : Genode::Bitset_2<Irgn_0, Irgn_1> { }; /* inner cache mode */
 	};
 
 	struct Ttbr_64bit : Genode::Register<64>

--- a/repos/base/include/drivers/defs/zynq.h
+++ b/repos/base/include/drivers/defs/zynq.h
@@ -47,6 +47,9 @@ namespace Zynq {
 		CORTEX_A9_PRIVATE_MEM_BASE  = 0xf8f00000,
 		CORTEX_A9_PRIVATE_MEM_SIZE  = 0x00002000,
 
+		/* entrypoint address of secondary cpu */
+		CORE1_ENTRY = 0xfffffff0,
+
 		/* CPU cache */
 		PL310_MMIO_BASE      = MMIO_1_BASE + 0xF02000,
 		PL310_MMIO_SIZE      = 0x1000,

--- a/repos/base/run/affinity.run
+++ b/repos/base/run/affinity.run
@@ -8,6 +8,7 @@ if {
 	![have_spec arndale]                           &&
 	![have_spec wand_quad]                         &&
 	![have_spec panda]                             &&
+	![expr [have_spec zynq] && ![have_spec zynq_qemu] ] &&
 	![expr [have_spec x86_32] && [have_spec foc] ] &&
 	![expr [have_spec x86_64] && [have_spec foc] ] &&
 	![have_spec nova] &&


### PR DESCRIPTION
Unfortunately, upstream qemu only implements a single core of the Cortex A9. Thus, zynq_qemu is still running with NR_OF_CPUS=1. I haven't tried the Xilinx version of qemu. I successfully executed affinity.run on real hardware though.

I'll create a separate pull request for genode-world where the spec files for the ZC706, ZC702, parallella and zedboard reside.