### PR TITLE
Add missing libc ABI symbols

### DIFF
--- a/repos/libports/lib/symbols/libc
+++ b/repos/libports/lib/symbols/libc
@@ -195,6 +195,7 @@ fseeko T
 fsetpos T
 fstat T
 fstatat T
+fstatfs T
 fstatvfs T
 fsync T
 ftell T


### PR DESCRIPTION
Those were missing to build FreeBSD's `rm`.