### PR TITLE
fix outdated hello_tutorial

### DIFF
--- a/repos/hello_tutorial/doc/hello_tutorial.txt
+++ b/repos/hello_tutorial/doc/hello_tutorial.txt
@@ -436,7 +436,8 @@ at the _run/hello.run_ and look as follows:
 !
 !run_genode_until "hello test completed.*\n" 10
 
-When executed via 'make run/hello', it performs the given steps in sequence.
+When executed via 'make run/hello KERNEL=linux', it performs the given steps in
+sequence.
 Note that the run script is kernel-agnostic. Hence, you can execute the system
 scenario on all the different kernels supported by Genode without any
 modification. The regular expression specified to the 'run_genode_until' step

--- a/repos/hello_tutorial/doc/hello_tutorial.txt
+++ b/repos/hello_tutorial/doc/hello_tutorial.txt
@@ -172,7 +172,7 @@ parameters.
 !{
 !  protected:
 !
-!    Session_component *_create_session(const char *args)
+!    Session_component *_create_session(const char *)
 !    {
 !      Genode::log("creating hello session");
 !      return new (md_alloc()) Session_component();

--- a/repos/hello_tutorial/run/hello.run
+++ b/repos/hello_tutorial/run/hello.run
@@ -39,5 +39,4 @@ build_boot_image { core ld.lib.so init hello_client hello_server }
 
 append qemu_args " -nographic "
 
-run_genode_until forever
 run_genode_until "hello test completed.*\n" 10

--- a/repos/hello_tutorial/src/hello/server/main.cc
+++ b/repos/hello_tutorial/src/hello/server/main.cc
@@ -42,7 +42,7 @@ class Hello::Root_component
 {
 	protected:
 
-		Session_component *_create_session(const char *args)
+		Session_component *_create_session(const char *)
 		{
 			Genode::log("creating hello session");
 			return new (md_alloc()) Session_component();


### PR DESCRIPTION
I failed to run `hello_tutorial` when trying to compile the already present code and following [hello_tutorial.txt](https://genode.org/documentation/developer-resources/client_server_tutorial) to start the run script. Please note that I have stopped fixing things when it worked with my setup. So there might still be further outdated parts in code/docs.