### PR TITLE
util/fifo: Change empty() method of fifo to const.

### DIFF
--- a/repos/base/include/util/fifo.h
+++ b/repos/base/include/util/fifo.h
@@ -67,7 +67,7 @@ class Genode::Fifo
 		/**
 		 * Return true if queue is empty
 		 */
-		bool empty() { return _tail == nullptr; }
+		bool empty() const { return _tail == nullptr; }
 
 		/**
 		 * Constructor


### PR DESCRIPTION
Fixes #3464