### PR TITLE
libc: Allow private writable mappings

### DIFF
--- a/repos/libports/src/lib/libc/vfs_plugin.cc
+++ b/repos/libports/src/lib/libc/vfs_plugin.cc
@@ -1258,7 +1258,7 @@ int Libc::Vfs_plugin::rename(char const *from_path, char const *to_path)
 void *Libc::Vfs_plugin::mmap(void *addr_in, ::size_t length, int prot, int flags,
                              Libc::File_descriptor *fd, ::off_t offset)
 {
-	if (prot != PROT_READ) {
+	if (prot != PROT_READ && !(prot == (PROT_READ | PROT_WRITE) && flags == MAP_PRIVATE)) {
 		Genode::error("mmap for prot=", Genode::Hex(prot), " not supported");
 		errno = EACCES;
 		return (void *)-1;


### PR DESCRIPTION
`mmap` is restricted to read-only mappings right now. As changes in memory are not carried through to the underlying file, this is the only sound option for shared mappings. However, as I'm interpreting [POSIX](https://pubs.opengroup.org/onlinepubs/009695399/functions/mmap.html), writable private mappings should be compatible with the current semantics:

> If MAP_PRIVATE is specified, modifications to the mapped data by the calling process shall be visible only to the calling process and shall not change the underlying object. It is unspecified whether modifications to the underlying object done after the MAP_PRIVATE mapping is established are visible through the MAP_PRIVATE mapping.

Any objections to relax the constraints of `mmap` for cases where `PROT_WRITE` is used together with `MAP_PRIVATE`?