### PR TITLE
base-hw: S2-translation changes do not properly update cache and TLB (update)

### DIFF
--- a/logs/before-fix/log-test-1-before.txt
+++ b/logs/before-fix/log-test-1-before.txt
@@ -1,0 +1,399 @@
+€
+U-Boot SPL 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:57:16 +0100)
+PMIC:  PFUZE100 ID=0x10
+DDRINFO: start DRAM init
+DDRINFO:ddrphy calibration done
+DDRINFO: ddrmix config done
+Normal Boot
+Trying to boot from MMC2
+
+
+U-Boot 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:13:51 +0100)
+
+CPU:   Freescale i.MX8MQ rev2.1 1500 MHz (running at 1000 MHz)
+CPU:   Commercial temperature grade (0C to 95C) at 37C
+Reset cause: POR
+Model: Freescale i.MX8MQ EVK
+DRAM:  3 GiB
+TCPC:  Vendor ID [0x1fc9], Product ID [0x5110], Addr [I2C0 0x50]
+MMC:   FSL_SDHC: 0, FSL_SDHC: 1
+Loading Environment from MMC... Run CMD11 1.8V switch
+OK
+No panel detected: default to HDMI
+Display: HDMI (1280x720)
+cdn_api_checkalive: keep-alive counter did not increment for 10us...
+HDMI enable failed!
+In:    serial
+Out:   serial
+Err:   serial
+
+ BuildInfo:
+  - ATF 413e93e
+  - U-Boot 2019.04-04771-g4d377539a1-dirty
+
+Run CMD11 1.8V switch
+switch to partitions #0, OK
+mmc1 is current device
+flash target is MMC:1
+Run CMD11 1.8V switch
+Net:   eth0: ethernet@30be0000
+Fastboot: Normal
+Normal Boot
+Hit any key to stop autoboot:  2  1  0 
+ethernet@30be0000 Waiting for PHY auto negotiation to complete.. done
+BOOTP broadcast 1
+BOOTP broadcast 2
+BOOTP broadcast 3
+BOOTP broadcast 4
+DHCP client bound to address 192.168.1.11 (1770 ms)
+Using ethernet@30be0000 device
+TFTP from server 192.168.1.1; our IP address is 192.168.1.11
+Filename 'genode'.
+Load address: 0x60000000
+Loading: *#################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 ##############################################################
+	 4.7 MiB/s
+done
+Bytes transferred = 9965307 (980efb hex)
+## Booting kernel from Legacy Image at 60000000 ...
+   Image Name:   
+   Image Type:   AArch64 Linux Kernel Image (gzip compressed)
+   Data Size:    9965243 Bytes = 9.5 MiB
+   Load Address: 40010000
+   Entry Point:  40010000
+   Verifying Checksum ... OK
+   Uncompressing Kernel Image ... OK
+
+Starting kernel ...
+
+
+kernel initialized
+ROM modules:
+ ROM: [0000000040240000,0000000040240710) config
+ ROM: [000000004000e000,000000004000f000) core_log
+ ROM: [0000000040241000,0000000040241665) dtb
+ ROM: [00000000401fe000,000000004023f550) init
+ ROM: [000000004145d000,0000000041507539) initrd
+ ROM: [0000000040138000,00000000401ede80) ld.lib.so
+ ROM: [0000000040272000,0000000041439200) linux
+ ROM: [000000004157e000,000000004158c970) log_terminal
+ ROM: [0000000041508000,000000004157d688) nic_router
+ ROM: [000000004000c000,000000004000d000) platform_info
+ ROM: [00000000401ee000,00000000401fdb48) terminal_crosslink
+ ROM: [000000004144b000,000000004145c770) test-terminal_expect_send
+ ROM: [000000004143a000,000000004144acd0) timer
+ ROM: [0000000040242000,0000000040272000) vmm
+
+Genode sculpt-20.02-74-gc9ff23eb0
+3047 MiB RAM and 64533 caps assigned to init
+[init] parent provides
+[init]   service "ROM"
+[init]   service "IRQ"
+[init]   service "IO_MEM"
+[init]   service "PD"
+[init]   service "RM"
+[init]   service "CPU"
+[init]   service "LOG"
+[init]   service "VM"
+[init] child "timer"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: timer
+[init]   priority:   0
+[init]   provides service Timer
+[init] child "nic_drv"
+[init]   RAM quota:  7944K
+[init]   cap quota:  68
+[init]   ELF binary: nic_router
+[init]   priority:   0
+[init]   provides service Nic
+[init] child "log_terminal"
+[init]   RAM quota:  1800K
+[init]   cap quota:  68
+[init]   ELF binary: log_terminal
+[init]   priority:   0
+[init]   provides service Terminal
+[init] child "terminal_crosslink"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: terminal_crosslink
+[init]   priority:   0
+[init]   provides service Terminal
+[init] child "vmm"
+[init]   RAM quota:  261896K
+[init]   cap quota:  168
+[init]   ELF binary: vmm
+[init]   priority:   1
+[init] child "vm"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: test-terminal_expect_send
+[init]   priority:   0
+[init] child "log_terminal" announces service "Terminal"
+[init] child "terminal_crosslink" announces service "Terminal"
+[init] child "timer" announces service "Timer"
+[init] child "nic_drv" announces service "Nic"
+[init -> vmm] Start virtual machine ...
+[init -> log_terminal] [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
+[init -> log_terminal] [    0.000000] Linux version 4.19.53 (cbass@kc87) (gcc version 8.3.0 (GCC)) #1 SMP PREEMPT Wed Jun 19 13:23:18 CEST 2019
+[init -> log_terminal] [    0.000000] Machine model: linux,dummy-virt
+[init -> log_terminal] [    0.000000] earlycon: pl11 at MMIO 0x0000000009000000 (options '')
+[init -> log_terminal] [    0.000000] bootconsole [pl11] enabled
+[init -> log_terminal] [    0.000000] efi: Getting EFI parameters from FDT:
+[init -> log_terminal] [    0.000000] efi: UEFI not found.
+[init -> log_terminal] [    0.000000] cma: Failed to reserve 32 MiB
+[init -> log_terminal] [    0.000000] NUMA: No NUMA configuration found
+[init -> log_terminal] [    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] NUMA: NODE_DATA [mem 0x43ff0b00-0x43ff22bf]
+[init -> log_terminal] [    0.000000] Zone ranges:
+[init -> log_terminal] [    0.000000]   DMA32    [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000]   Normal   empty
+[init -> log_terminal] [    0.000000] Movable zone start for each node
+[init -> log_terminal] [    0.000000] Early memory node ranges
+[init -> log_terminal] [    0.000000]   node   0: [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] random: get_random_bytes called from start_kernel+0x94/0x400 with crng_init=0
+[init -> log_terminal] [    0.000000] percpu: Embedded 23 pages/cpu s56408 r8192 d29608 u94208
+[init -> log_terminal] [    0.000000] Detected VIPT I-cache on CPU0
+[init -> log_terminal] [    0.000000] CPU features: enabling workaround for ARM erratum 843419
+[init -> log_terminal] [    0.000000] CPU features: enabling workaround for ARM erratum 845719
+[init -> log_terminal] [    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
+[init -> log_terminal] [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 16128
+[init -> log_terminal] [    0.000000] Policy zone: DMA32
+[init -> log_terminal] [    0.000000] Kernel command line: rdinit=/bin/sh console=hvc0 earlycon=pl011,0x9000000
+[init -> log_terminal] [    0.000000] Memory: 29680K/65536K available (10556K kernel code, 1372K rwdata, 4900K rodata, 1344K init, 380K bss, 35856K reserved, 0K cma-reserved)
+[init -> log_terminal] [    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[init -> log_terminal] [    0.000000] rcu: Preemptible hierarchical RCU implementation.
+[init -> log_terminal] [    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=1.
+[init -> log_terminal] [    0.000000] 	Tasks RCU enabled.
+[init -> log_terminal] [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[init -> log_terminal] [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+[init -> log_terminal] [    0.000000] GICv3: Distributor has no Range Selector support
+[init -> log_terminal] [    0.000000] GICv3: no VLPI support, no direct LPI support
+[init -> log_terminal] [    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x00000000080a0000
+[init -> vmm] Warning: Invalid write access to register GICR_WAKER address=0x0 width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0x80a0014)
+[init -> vmm] Warning: Invalid write access to register GICR_IGROUPR0 address=0x0 width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0x80b0080)
+[init -> log_terminal] [    0.000000] arch_timer: cp15 timer(s) running at 8.33MHz (virt).
+[init -> log_terminal] [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x1ec0311ec, max_idle_ns: 440795202152 ns
+[init -> log_terminal] [    0.000005] sched_clock: 56 bits at 8MHz, resolution 120ns, wraps every 2199023255541ns
+[init -> log_terminal] [    0.047620] Console: colour dummy device 80x25
+[init -> log_terminal] [    0.075681] Calibrating delay loop (skipped), value calculated using timer frequency.. 16.66 BogoMIPS (lpj=33333)
+[init -> log_terminal] [    0.135919] pid_max: default: 32768 minimum: 301
+[init -> log_terminal] [    0.166288] Security Framework initialized
+[init -> log_terminal] [    0.192262] Dentry cache hash table entries: 8192 (order: 4, 65536 bytes)
+[init -> log_terminal] [    0.233145] Inode-cache hash table entries: 4096 (order: 3, 32768 bytes)
+[init -> log_terminal] [    0.274061] Mount-cache hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    0.313462] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    0.391380] ASID allocator initialised with 32768 entries
+[init -> log_terminal] [    0.436340] rcu: Hierarchical SRCU implementation.
+[init -> log_terminal] [    0.477869] EFI services will not be available.
+[init -> log_terminal] [    0.517591] smp: Bringing up secondary CPUs ...
+[init -> log_terminal] [    0.545860] smp: Brought up 1 node, 1 CPU
+[init -> log_terminal] [    0.571183] SMP: Total of 1 processors activated.
+[init -> log_terminal] [    0.738112] CPU: All CPU(s) started at EL1
+[init -> log_terminal] [    0.763921] alternatives: patching kernel code
+[init -> log_terminal] [    0.792319] devtmpfs: initialized
+[init -> log_terminal] [    0.820509] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[init -> log_terminal] [    0.877927] futex hash table entries: 256 (order: 2, 16384 bytes)
+[init -> log_terminal] [    0.915403] pinctrl core: initialized pinctrl subsystem
+[init -> log_terminal] [    0.949467] DMI not present or invalid.
+[init -> log_terminal] [    0.975867] NET: Registered protocol family 16
+[init -> log_terminal] [    1.004476] audit: initializing netlink subsys (disabled)
+[init -> log_terminal] [    1.039212] cpuidle: using governor menu
+[init -> log_terminal] [    1.064323] audit: type=2000 audit(0.272:1): state=initialized audit_enabled=0 res=1
+[init -> log_terminal] [    1.112368] vdso: 2 pages (1 code @ (____ptrval____), 1 data @ (____ptrval____))
+[init -> log_terminal] [    1.156797] hw-breakpoint: found 1 breakpoint and 1 watchpoint registers.
+[init -> log_terminal] [    1.198702] DMA: preallocated 256 KiB pool for atomic allocations
+[init -> log_terminal] [    1.238154] Serial: AMBA PL011 UART driver
+[init -> log_terminal] [    1.267230] 9000000.pl011: ttyAMA0 at MMIO 0x9000000 (irq = 5, base_baud = 0) is a PL011 rev1
+[init -> log_terminal] [    1.368785] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[init -> log_terminal] [    1.415917] cryptd: max_cpu_qlen set to 1000
+[init -> log_terminal] [    1.455944] ACPI: Interpreter disabled.
+[init -> log_terminal] [    1.481941] vgaarb: loaded
+[init -> log_terminal] [    1.501171] SCSI subsystem initialized
+[init -> log_terminal] [    1.531630] usbcore: registered new interface driver usbfs
+[init -> log_terminal] [    1.566094] usbcore: registered new interface driver hub
+[init -> log_terminal] [    1.598856] usbcore: registered new device driver usb
+[init -> log_terminal] [    1.630859] pps_core: LinuxPPS API ver. 1 registered
+[init -> log_terminal] [    1.662134] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[init -> log_terminal] [    1.716196] PTP clock support registered
+[init -> log_terminal] [    1.741393] EDAC MC: Ver: 3.0.0
+[init -> log_terminal] [    1.774876] Advanced Linux Sound Architecture Driver Initialized.
+[init -> log_terminal] [    1.812975] clocksource: Switched to clocksource arch_sys_counter
+[init -> log_terminal] [    1.852387] VFS: Disk quotas dquot_6.6.0
+[init -> log_terminal] [    1.877625] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[init -> log_terminal] [    1.919532] pnp: PnP ACPI: disabled
+[init -> log_terminal] [    1.956855] NET: Registered protocol family 2
+[init -> log_terminal] [    1.986665] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes)
+[init -> log_terminal] [    2.032536] TCP established hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    2.073927] TCP bind hash table entries: 512 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.111900] TCP: Hash tables configured (established 512 bind 512)
+[init -> log_terminal] [    2.149411] UDP hash table entries: 256 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.184948] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.223375] NET: Registered protocol family 1
+[init -> log_terminal] [    2.268725] RPC: Registered named UNIX socket transport module.
+[init -> log_terminal] [    2.304733] RPC: Registered udp transport module.
+[init -> log_terminal] [    2.333955] RPC: Registered tcp transport module.
+[init -> log_terminal] [    2.363164] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[init -> log_terminal] [    2.402229] Unpacking initramfs...
+[init -> log_terminal] [    2.466816] Freeing initrd memory: 680K
+[init -> log_terminal] [    2.491795] kvm [1]: HYP mode not available
+[init -> log_terminal] [    2.520812] Initialise system trusted keyrings
+[init -> log_terminal] [    2.550010] workingset: timestamp_bits=44 max_order=13 bucket_order=0
+[init -> log_terminal] [    2.605600] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[init -> log_terminal] [    2.649864] NFS: Registering the id_resolver key type
+[init -> log_terminal] [    2.681557] Key type id_resolver registered
+[init -> log_terminal] [    2.707919] Key type id_legacy registered
+[init -> log_terminal] [    2.733285] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+[init -> log_terminal] [    2.773874] 9p: Installing v9fs 9p2000 file system support
+[init -> log_terminal] [    2.811011] Key type asymmetric registered
+[init -> log_terminal] [    2.836917] Asymmetric key parser 'x509' registered
+[init -> log_terminal] [    2.867270] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 244)
+[init -> log_terminal] [    2.911601] io scheduler noop registered
+[init -> log_terminal] [    2.936941] io scheduler deadline registered
+[init -> log_terminal] [    2.963892] io scheduler cfq registered (default)
+[init -> log_terminal] [    2.993169] io scheduler mq-deadline registered
+[init -> log_terminal] [    3.021454] io scheduler kyber registered
+[init -> log_terminal] [    3.060529] EINJ: ACPI disabled.
+[init -> log_terminal] [    3.101541] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
+[init -> log_terminal] [    3.142913] SuperH (H)SCI(F) driver initialized
+[init -> log_terminal] [    3.173587] msm_serial: driver initialized
+[init -> log_terminal] [    3.209618] console [hvc0] enabled
+[init -> log_terminal] [    3.232002] bootconsole [pl11] disabled
+[init -> vm] [    3.268474] loop: module loaded
+[init -> vm] [    3.282990] libphy: Fixed MDIO Bus: probed
+[init -> vm] [    3.291938] tun: Universal TUN/TAP device driver, 1.6
+[init -> vmm] Warning: Could not find address=0xfc width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0xa0002fc)
+[init -> vmm] Warning: Could not find address=0xfc width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0xa0002fc)
+[init -> vm] [    3.340866] thunder_xcv, ver 1.0
+[init -> vm] [    3.348010] thunder_bgx, ver 1.0
+[init -> vm] [    3.354622] nicpf, ver 1.0
+[init -> vm] [    3.360753] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
+[init -> vm] [    3.370721] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
+[init -> vm] [    3.380530] igb: Intel(R) Gigabit Ethernet Network Driver - version 5.4.0-k
+[init -> vm] [    3.391377] igb: Copyright (c) 2007-2014 Intel Corporation.
+[init -> vm] [    3.400569] igbvf: Intel(R) Gigabit Virtual Function Network Driver - version 2.4.0-k
+[init -> vm] [    3.412514] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
+[init -> vm] [    3.422555] sky2: driver version 1.30
+[init -> vm] [    3.430695] VFIO - User Level meta-driver version: 0.3
+[init -> vm] [    3.446758] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[init -> vm] [    3.457741] ehci-pci: EHCI PCI platform driver
+[init -> vm] [    3.465853] ehci-platform: EHCI generic platform driver
+[init -> vm] [    3.474801] ehci-orion: EHCI orion driver
+[init -> vm] [    3.482205] ehci-exynos: EHCI EXYNOS driver
+[init -> vm] [    3.489805] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[init -> vm] [    3.499852] ohci-pci: OHCI PCI platform driver
+[init -> vm] [    3.507894] ohci-platform: OHCI generic platform driver
+[init -> vm] [    3.516782] ohci-exynos: OHCI EXYNOS driver
+[init -> vm] [    3.524688] usbcore: registered new interface driver usb-storage
+[init -> vm] [    3.537950] i2c /dev entries driver
+[init -> vm] [    3.551544] sdhci: Secure Digital Host Controller Interface driver
+[init -> vm] [    3.563906] sdhci: Copyright(c) Pierre Ossman
+[init -> vm] [    3.572299] Synopsys Designware Multimedia Card Interface Driver
+[init -> vm] [    3.583175] sdhci-pltfm: SDHCI platform and OF driver helper
+[init -> vm] [    3.594286] ledtrig-cpu: registered to indicate activity on CPUs
+[init -> vm] [    3.606611] usbcore: registered new interface driver usbhid
+[init -> vm] [    3.616839] usbhid: USB HID core driver
+[init -> vm] [    3.627274] NET: Registered protocol family 17
+[init -> vm] [    3.636762] 9pnet: Installing 9P2000 support
+[init -> vm] [    3.644722] Key type dns_resolver registered
+[init -> vm] [    3.653644] registered taskstats version 1
+[init -> vm] [    3.661494] Loading compiled-in X.509 certificates
+[init -> vm] [    3.670158] hctosys: unable to open rtc device (rtc0)
+[init -> vm] [    3.678850] ALSA device list:
+[init -> vm] [    3.685381]   No soundcards found.
+[init -> vm] [    3.692788] Freeing unused kernel memory: 1344K
+[init -> vm] [    3.700930] Run /bin/sh as init process
+[init -> vm] /bin/sh: can't access tty; job control turned off
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vmm] Start test 1
+[init -> vmm] entire detach
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+À
+U-Boot SPL 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:57:16 +0100)
+PMIC:  PFUZE100 ID=0x10
+DDRINFO: start DRAM init
+DDRINFO:ddrphy calibration done
+DDRINFO: ddrmix config done
+Normal Boot
+Trying to boot from MMC2
+
+
+U-Boot 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:13:51 +0100)
+
+CPU:   Freescale i.MX8MQ rev2.1 1500 MHz (running at 1000 MHz)
+CPU:   Commercial temperature grade (0C to 95C) at 37C
+Reset cause: POR
+Model: Freescale i.MX8MQ EVK
+DRAM:  3 GiB
+TCPC:  Vendor ID [0x1fc9], Product ID [0x5110], Addr [I2C0 0x50]
+MMC:   FSL_SDHC: 0, FSL_SDHC: 1
+Loading Environment from MMC... Run CMD11 1.8V switch
+OK
+No panel detected: default to HDMI
+Display: HDMI (1280x720)
+cdn_api_checkalive: keep-alive counter did not increment for 10us...
+HDMI enable failed!
+In:    serial
+Out:   serial
+Err:   serial
+
+ BuildInfo:
+  - ATF 413e93e
+  - U-Boot 2019.04-04771-g4d377539a1-dirty
+
+Run CMD11 1.8V switch
+switch to partitions #0, OK
+mmc1 is current device
+flash target is MMC:1
+Run CMD11 1.8V switch
+Net:   eth0: ethernet@30be0000
+Fastboot: Normal
+Normal Boot
+Hit any key to stop autoboot:  2  0
+u-boot=>        

--- a/logs/before-fix/log-test-3-before.txt
+++ b/logs/before-fix/log-test-3-before.txt
@@ -1,0 +1,398 @@
+À
+U-Boot SPL 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:57:16 +0100)
+PMIC:  PFUZE100 ID=0x10
+DDRINFO: start DRAM init
+DDRINFO:ddrphy calibration done
+DDRINFO: ddrmix config done
+Normal Boot
+Trying to boot from MMC2
+
+
+U-Boot 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:13:51 +0100)
+
+CPU:   Freescale i.MX8MQ rev2.1 1500 MHz (running at 1000 MHz)
+CPU:   Commercial temperature grade (0C to 95C) at 37C
+Reset cause: POR
+Model: Freescale i.MX8MQ EVK
+DRAM:  3 GiB
+TCPC:  Vendor ID [0x1fc9], Product ID [0x5110], Addr [I2C0 0x50]
+MMC:   FSL_SDHC: 0, FSL_SDHC: 1
+Loading Environment from MMC... Run CMD11 1.8V switch
+OK
+No panel detected: default to HDMI
+Display: HDMI (1280x720)
+cdn_api_checkalive: keep-alive counter did not increment for 10us...
+HDMI enable failed!
+In:    serial
+Out:   serial
+Err:   serial
+
+ BuildInfo:
+  - ATF 413e93e
+  - U-Boot 2019.04-04771-g4d377539a1-dirty
+
+Run CMD11 1.8V switch
+switch to partitions #0, OK
+mmc1 is current device
+flash target is MMC:1
+Run CMD11 1.8V switch
+Net:   eth0: ethernet@30be0000
+Fastboot: Normal
+Normal Boot
+Hit any key to stop autoboot:  2  1  0 
+ethernet@30be0000 Waiting for PHY auto negotiation to complete.. done
+BOOTP broadcast 1
+BOOTP broadcast 2
+BOOTP broadcast 3
+DHCP client bound to address 192.168.1.11 (1003 ms)
+Using ethernet@30be0000 device
+TFTP from server 192.168.1.1; our IP address is 192.168.1.11
+Filename 'genode'.
+Load address: 0x60000000
+Loading: *#################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 ##############################################################
+	 4.6 MiB/s
+done
+Bytes transferred = 9965609 (981029 hex)
+## Booting kernel from Legacy Image at 60000000 ...
+   Image Name:   
+   Image Type:   AArch64 Linux Kernel Image (gzip compressed)
+   Data Size:    9965545 Bytes = 9.5 MiB
+   Load Address: 40010000
+   Entry Point:  40010000
+   Verifying Checksum ... OK
+   Uncompressing Kernel Image ... OK
+
+Starting kernel ...
+
+
+kernel initialized
+ROM modules:
+ ROM: [0000000040240000,0000000040240710) config
+ ROM: [000000004000d000,000000004000e000) core_log
+ ROM: [0000000040241000,0000000040241665) dtb
+ ROM: [00000000401fe000,000000004023f550) init
+ ROM: [000000004145e000,0000000041508539) initrd
+ ROM: [0000000040138000,00000000401ede80) ld.lib.so
+ ROM: [0000000040273000,000000004143a200) linux
+ ROM: [000000004157f000,000000004158d970) log_terminal
+ ROM: [0000000041509000,000000004157e688) nic_router
+ ROM: [000000004000b000,000000004000c000) platform_info
+ ROM: [00000000401ee000,00000000401fdb48) terminal_crosslink
+ ROM: [000000004144c000,000000004145d770) test-terminal_expect_send
+ ROM: [000000004143b000,000000004144bcd0) timer
+ ROM: [0000000040242000,0000000040272018) vmm
+
+Genode sculpt-20.02-74-gc9ff23eb0 <local changes>
+3047 MiB RAM and 64533 caps assigned to init
+[init] parent provides
+[init]   service "ROM"
+[init]   service "IRQ"
+[init]   service "IO_MEM"
+[init]   service "PD"
+[init]   service "RM"
+[init]   service "CPU"
+[init]   service "LOG"
+[init]   service "VM"
+[init] child "timer"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: timer
+[init]   priority:   0
+[init]   provides service Timer
+[init] child "nic_drv"
+[init]   RAM quota:  7944K
+[init]   cap quota:  68
+[init]   ELF binary: nic_router
+[init]   priority:   0
+[init]   provides service Nic
+[init] child "log_terminal"
+[init]   RAM quota:  1800K
+[init]   cap quota:  68
+[init]   ELF binary: log_terminal
+[init]   priority:   0
+[init]   provides service Terminal
+[init] child "terminal_crosslink"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: terminal_crosslink
+[init]   priority:   0
+[init]   provides service Terminal
+[init] child "vmm"
+[init]   RAM quota:  261896K
+[init]   cap quota:  168
+[init]   ELF binary: vmm
+[init]   priority:   1
+[init] child "vm"
+[init]   RAM quota:  776K
+[init]   cap quota:  68
+[init]   ELF binary: test-terminal_expect_send
+[init]   priority:   0
+[init] child "log_terminal" announces service "Terminal"
+[init] child "terminal_crosslink" announces service "Terminal"
+[init] child "timer" announces service "Timer"
+[init] child "nic_drv" announces service "Nic"
+[init -> vmm] Start virtual machine ...
+[init -> log_terminal] [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
+[init -> log_terminal] [    0.000000] Linux version 4.19.53 (cbass@kc87) (gcc version 8.3.0 (GCC)) #1 SMP PREEMPT Wed Jun 19 13:23:18 CEST 2019
+[init -> log_terminal] [    0.000000] Machine model: linux,dummy-virt
+[init -> log_terminal] [    0.000000] earlycon: pl11 at MMIO 0x0000000009000000 (options '')
+[init -> log_terminal] [    0.000000] bootconsole [pl11] enabled
+[init -> log_terminal] [    0.000000] efi: Getting EFI parameters from FDT:
+[init -> log_terminal] [    0.000000] efi: UEFI not found.
+[init -> log_terminal] [    0.000000] cma: Failed to reserve 32 MiB
+[init -> log_terminal] [    0.000000] NUMA: No NUMA configuration found
+[init -> log_terminal] [    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] NUMA: NODE_DATA [mem 0x43ff0b00-0x43ff22bf]
+[init -> log_terminal] [    0.000000] Zone ranges:
+[init -> log_terminal] [    0.000000]   DMA32    [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000]   Normal   empty
+[init -> log_terminal] [    0.000000] Movable zone start for each node
+[init -> log_terminal] [    0.000000] Early memory node ranges
+[init -> log_terminal] [    0.000000]   node   0: [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x0000000043ffffff]
+[init -> log_terminal] [    0.000000] random: get_random_bytes called from start_kernel+0x94/0x400 with crng_init=0
+[init -> log_terminal] [    0.000000] percpu: Embedded 23 pages/cpu s56408 r8192 d29608 u94208
+[init -> log_terminal] [    0.000000] Detected VIPT I-cache on CPU0
+[init -> log_terminal] [    0.000000] CPU features: enabling workaround for ARM erratum 843419
+[init -> log_terminal] [    0.000000] CPU features: enabling workaround for ARM erratum 845719
+[init -> log_terminal] [    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
+[init -> log_terminal] [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 16128
+[init -> log_terminal] [    0.000000] Policy zone: DMA32
+[init -> log_terminal] [    0.000000] Kernel command line: rdinit=/bin/sh console=hvc0 earlycon=pl011,0x9000000
+[init -> log_terminal] [    0.000000] Memory: 29680K/65536K available (10556K kernel code, 1372K rwdata, 4900K rodata, 1344K init, 380K bss, 35856K reserved, 0K cma-reserved)
+[init -> log_terminal] [    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
+[init -> log_terminal] [    0.000000] rcu: Preemptible hierarchical RCU implementation.
+[init -> log_terminal] [    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=1.
+[init -> log_terminal] [    0.000000] 	Tasks RCU enabled.
+[init -> log_terminal] [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
+[init -> log_terminal] [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+[init -> log_terminal] [    0.000000] GICv3: Distributor has no Range Selector support
+[init -> log_terminal] [    0.000000] GICv3: no VLPI support, no direct LPI support
+[init -> log_terminal] [    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x00000000080a0000
+[init -> vmm] Warning: Invalid write access to register GICR_WAKER address=0x0 width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0x80a0014)
+[init -> vmm] Warning: Invalid write access to register GICR_IGROUPR0 address=0x0 width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0x80b0080)
+[init -> log_terminal] [    0.000000] arch_timer: cp15 timer(s) running at 8.33MHz (virt).
+[init -> log_terminal] [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x1ec0311ec, max_idle_ns: 440795202152 ns
+[init -> log_terminal] [    0.000005] sched_clock: 56 bits at 8MHz, resolution 120ns, wraps every 2199023255541ns
+[init -> log_terminal] [    0.047719] Console: colour dummy device 80x25
+[init -> log_terminal] [    0.075826] Calibrating delay loop (skipped), value calculated using timer frequency.. 16.66 BogoMIPS (lpj=33333)
+[init -> log_terminal] [    0.136171] pid_max: default: 32768 minimum: 301
+[init -> log_terminal] [    0.166578] Security Framework initialized
+[init -> log_terminal] [    0.192626] Dentry cache hash table entries: 8192 (order: 4, 65536 bytes)
+[init -> log_terminal] [    0.233556] Inode-cache hash table entries: 4096 (order: 3, 32768 bytes)
+[init -> log_terminal] [    0.274533] Mount-cache hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    0.313986] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    0.392451] ASID allocator initialised with 32768 entries
+[init -> log_terminal] [    0.437082] rcu: Hierarchical SRCU implementation.
+[init -> log_terminal] [    0.478662] EFI services will not be available.
+[init -> log_terminal] [    0.518427] smp: Bringing up secondary CPUs ...
+[init -> log_terminal] [    0.546735] smp: Brought up 1 node, 1 CPU
+[init -> log_terminal] [    0.572109] SMP: Total of 1 processors activated.
+[init -> log_terminal] [    0.739502] CPU: All CPU(s) started at EL1
+[init -> log_terminal] [    0.765362] alternatives: patching kernel code
+[init -> log_terminal] [    0.793815] devtmpfs: initialized
+[init -> log_terminal] [    0.822048] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[init -> log_terminal] [    0.879526] futex hash table entries: 256 (order: 2, 16384 bytes)
+[init -> log_terminal] [    0.917146] pinctrl core: initialized pinctrl subsystem
+[init -> log_terminal] [    0.951260] DMI not present or invalid.
+[init -> log_terminal] [    0.977697] NET: Registered protocol family 16
+[init -> log_terminal] [    1.006335] audit: initializing netlink subsys (disabled)
+[init -> log_terminal] [    1.041152] cpuidle: using governor menu
+[init -> log_terminal] [    1.066295] audit: type=2000 audit(0.276:1): state=initialized audit_enabled=0 res=1
+[init -> log_terminal] [    1.114450] vdso: 2 pages (1 code @ (____ptrval____), 1 data @ (____ptrval____))
+[init -> log_terminal] [    1.158991] hw-breakpoint: found 1 breakpoint and 1 watchpoint registers.
+[init -> log_terminal] [    1.200993] DMA: preallocated 256 KiB pool for atomic allocations
+[init -> log_terminal] [    1.240517] Serial: AMBA PL011 UART driver
+[init -> log_terminal] [    1.269667] 9000000.pl011: ttyAMA0 at MMIO 0x9000000 (irq = 5, base_baud = 0) is a PL011 rev1
+[init -> log_terminal] [    1.364971] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[init -> log_terminal] [    1.412444] cryptd: max_cpu_qlen set to 1000
+[init -> log_terminal] [    1.452556] ACPI: Interpreter disabled.
+[init -> log_terminal] [    1.478611] vgaarb: loaded
+[init -> log_terminal] [    1.497867] SCSI subsystem initialized
+[init -> log_terminal] [    1.528362] usbcore: registered new interface driver usbfs
+[init -> log_terminal] [    1.562848] usbcore: registered new interface driver hub
+[init -> log_terminal] [    1.595635] usbcore: registered new device driver usb
+[init -> log_terminal] [    1.627688] pps_core: LinuxPPS API ver. 1 registered
+[init -> log_terminal] [    1.659031] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[init -> log_terminal] [    1.713178] PTP clock support registered
+[init -> log_terminal] [    1.738411] EDAC MC: Ver: 3.0.0
+[init -> log_terminal] [    1.771948] Advanced Linux Sound Architecture Driver Initialized.
+[init -> log_terminal] [    1.810122] clocksource: Switched to clocksource arch_sys_counter
+[init -> log_terminal] [    1.849570] VFS: Disk quotas dquot_6.6.0
+[init -> log_terminal] [    1.874854] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[init -> log_terminal] [    1.916904] pnp: PnP ACPI: disabled
+[init -> log_terminal] [    1.954945] NET: Registered protocol family 2
+[init -> log_terminal] [    1.984077] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes)
+[init -> log_terminal] [    2.030011] TCP established hash table entries: 512 (order: 0, 4096 bytes)
+[init -> log_terminal] [    2.071473] TCP bind hash table entries: 512 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.109470] TCP: Hash tables configured (established 512 bind 512)
+[init -> log_terminal] [    2.147039] UDP hash table entries: 256 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.182633] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes)
+[init -> log_terminal] [    2.221115] NET: Registered protocol family 1
+[init -> log_terminal] [    2.266765] RPC: Registered named UNIX socket transport module.
+[init -> log_terminal] [    2.302861] RPC: Registered udp transport module.
+[init -> log_terminal] [    2.332122] RPC: Registered tcp transport module.
+[init -> log_terminal] [    2.361385] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[init -> log_terminal] [    2.400893] Unpacking initramfs...
+[init -> log_terminal] [    2.464876] Freeing initrd memory: 680K
+[init -> log_terminal] [    2.489846] kvm [1]: HYP mode not available
+[init -> log_terminal] [    2.519187] Initialise system trusted keyrings
+[init -> log_terminal] [    2.548134] workingset: timestamp_bits=44 max_order=13 bucket_order=0
+[init -> log_terminal] [    2.603319] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[init -> log_terminal] [    2.647739] NFS: Registering the id_resolver key type
+[init -> log_terminal] [    2.679184] Key type id_resolver registered
+[init -> log_terminal] [    2.705592] Key type id_legacy registered
+[init -> log_terminal] [    2.731008] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+[init -> log_terminal] [    2.771682] 9p: Installing v9fs 9p2000 file system support
+[init -> log_terminal] [    2.808856] Key type asymmetric registered
+[init -> log_terminal] [    2.834796] Asymmetric key parser 'x509' registered
+[init -> log_terminal] [    2.865192] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 244)
+[init -> log_terminal] [    2.910011] io scheduler noop registered
+[init -> log_terminal] [    2.934948] io scheduler deadline registered
+[init -> log_terminal] [    2.961926] io scheduler cfq registered (default)
+[init -> log_terminal] [    2.991242] io scheduler mq-deadline registered
+[init -> log_terminal] [    3.019566] io scheduler kyber registered
+[init -> log_terminal] [    3.059177] EINJ: ACPI disabled.
+[init -> log_terminal] [    3.099303] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
+[init -> log_terminal] [    3.141279] SuperH (H)SCI(F) driver initialized
+[init -> log_terminal] [    3.171972] msm_serial: driver initialized
+[init -> log_terminal] [    3.208062] console [hvc0] enabled
+[init -> log_terminal] [    3.230786] bootconsole [pl11] disabled
+[init -> vm] [    3.267488] loop: module loaded
+[init -> vm] [    3.281640] libphy: Fixed MDIO Bus: probed
+[init -> vm] [    3.291111] tun: Universal TUN/TAP device driver, 1.6
+[init -> vmm] Warning: Could not find address=0xfc width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0xa0002fc)
+[init -> vmm] Warning: Could not find address=0xfc width=0x4
+[init -> vmm] Warning: Will ignore invalid bus access (IPA=0xa0002fc)
+[init -> vm] [    3.340308] thunder_xcv, ver 1.0
+[init -> vm] [    3.347446] thunder_bgx, ver 1.0
+[init -> vm] [    3.354045] nicpf, ver 1.0
+[init -> vm] [    3.360188] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
+[init -> vm] [    3.370420] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
+[init -> vm] [    3.380256] igb: Intel(R) Gigabit Ethernet Network Driver - version 5.4.0-k
+[init -> vm] [    3.391404] igb: Copyright (c) 2007-2014 Intel Corporation.
+[init -> vm] [    3.400605] igbvf: Intel(R) Gigabit Virtual Function Network Driver - version 2.4.0-k
+[init -> vm] [    3.412554] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
+[init -> vm] [    3.422597] sky2: driver version 1.30
+[init -> vm] [    3.430705] VFIO - User Level meta-driver version: 0.3
+[init -> vm] [    3.446868] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[init -> vm] [    3.457993] ehci-pci: EHCI PCI platform driver
+[init -> vm] [    3.466067] ehci-platform: EHCI generic platform driver
+[init -> vm] [    3.474956] ehci-orion: EHCI orion driver
+[init -> vm] [    3.482694] ehci-exynos: EHCI EXYNOS driver
+[init -> vm] [    3.490566] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[init -> vm] [    3.500614] ohci-pci: OHCI PCI platform driver
+[init -> vm] [    3.508653] ohci-platform: OHCI generic platform driver
+[init -> vm] [    3.517538] ohci-exynos: OHCI EXYNOS driver
+[init -> vm] [    3.525444] usbcore: registered new interface driver usb-storage
+[init -> vm] [    3.538700] i2c /dev entries driver
+[init -> vm] [    3.552041] sdhci: Secure Digital Host Controller Interface driver
+[init -> vm] [    3.565011] sdhci: Copyright(c) Pierre Ossman
+[init -> vm] [    3.573355] Synopsys Designware Multimedia Card Interface Driver
+[init -> vm] [    3.584309] sdhci-pltfm: SDHCI platform and OF driver helper
+[init -> vm] [    3.595467] ledtrig-cpu: registered to indicate activity on CPUs
+[init -> vm] [    3.607786] usbcore: registered new interface driver usbhid
+[init -> vm] [    3.618022] usbhid: USB HID core driver
+[init -> vm] [    3.628458] NET: Registered protocol family 17
+[init -> vm] [    3.637945] 9pnet: Installing 9P2000 support
+[init -> vm] [    3.645906] Key type dns_resolver registered
+[init -> vm] [    3.654825] registered taskstats version 1
+[init -> vm] [    3.662681] Loading compiled-in X.509 certificates
+[init -> vm] [    3.671344] hctosys: unable to open rtc device (rtc0)
+[init -> vm] [    3.680040] ALSA device list:
+[init -> vm] [    3.686569]   No soundcards found.
+[init -> vm] [    3.693976] Freeing unused kernel memory: 1344K
+[init -> vm] [    3.702411] Run /bin/sh as init process
+[init -> vm] /bin/sh: can't access tty; job control turned off
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vmm] Start test 3
+[init -> vmm] individual detach
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+[init -> vm] / # 
+[init -> vm] / # sleep 1
+À
+U-Boot SPL 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:57:16 +0100)
+PMIC:  PFUZE100 ID=0x10
+DDRINFO: start DRAM init
+DDRINFO:ddrphy calibration done
+DDRINFO: ddrmix config done
+Normal Boot
+Trying to boot from MMC2
+
+
+U-Boot 2019.04-04771-g4d377539a1-dirty (Mar 05 2020 - 14:13:51 +0100)
+
+CPU:   Freescale i.MX8MQ rev2.1 1500 MHz (running at 1000 MHz)
+CPU:   Commercial temperature grade (0C to 95C) at 37C
+Reset cause: POR
+Model: Freescale i.MX8MQ EVK
+DRAM:  3 GiB
+TCPC:  Vendor ID [0x1fc9], Product ID [0x5110], Addr [I2C0 0x50]
+MMC:   FSL_SDHC: 0, FSL_SDHC: 1
+Loading Environment from MMC... Run CMD11 1.8V switch
+OK
+No panel detected: default to HDMI
+Display: HDMI (1280x720)
+cdn_api_checkalive: keep-alive counter did not increment for 10us...
+HDMI enable failed!
+In:    serial
+Out:   serial
+Err:   serial
+
+ BuildInfo:
+  - ATF 413e93e
+  - U-Boot 2019.04-04771-g4d377539a1-dirty
+
+Run CMD11 1.8V switch
+switch to partitions #0, OK
+mmc1 is current device
+flash target is MMC:1
+Run CMD11 1.8V switch
+Net:   eth0: ethernet@30be0000
+Fastboot: Normal
+Normal Boot
+Hit any key to stop autoboot:  2  0
+u-boot=>        

--- a/logs/before-fix/readme-log-test-2-4-before.txt
+++ b/logs/before-fix/readme-log-test-2-4-before.txt
@@ -1,0 +1,1 @@
+These tests do not make sense before a fix, since the rely on proper detaching.

--- a/repos/base-hw/src/bootstrap/spec/imx8q_evk/board.h
+++ b/repos/base-hw/src/bootstrap/spec/imx8q_evk/board.h
@@ -30,4 +30,7 @@ namespace Board {
 	using Hw::Pic;
 };
 
+template <unsigned BLOCK_SIZE_LOG2, unsigned SZ_LOG2>
+void Hw::Long_translation_table<BLOCK_SIZE_LOG2, SZ_LOG2>::_update_cache(unsigned long, unsigned long) { }
+
 #endif /* _BOOTSTRAP__SPEC__IMX8Q_EVK__BOARD_H_ */

--- a/repos/base-hw/src/core/kernel/vm.h
+++ b/repos/base-hw/src/core/kernel/vm.h
@@ -54,6 +54,16 @@ class Kernel::Vm : public Cpu_job
 		void             * const    _table;
 		Scheduler_state             _scheduled = INACTIVE;
 		Board::Vcpu_context         _vcpu_context;
+		
+		/* This flag tells the hypervisor, that it 
+		 * should invalidate TLB entries for all VMs
+		 * on a worldswitch.
+		 *
+		 * Additional kernel-API would allow to set 
+     * it per VM (not static), such that TLB-invalidation 
+		 * is possible respective to the VMID.			
+		 */	 
+		static bool                 _inval_tlb_vm;
 
 	public:
 
@@ -136,6 +146,7 @@ class Kernel::Vm : public Cpu_job
 		void exception(Cpu & cpu) override;
 		void proceed(Cpu &  cpu)  override;
 		Cpu_job * helping_sink()  override { return this; }
+		static void invalidate_tlb_vm();
 };
 
 #endif /* _CORE__KERNEL__VM_H_ */

--- a/repos/base-hw/src/core/spec/arm/virtualization/vm_session_component.cc
+++ b/repos/base-hw/src/core/spec/arm/virtualization/vm_session_component.cc
@@ -36,6 +36,7 @@ void Vm_session_component::_attach(addr_t phys_addr, addr_t vm_addr, size_t size
 	try {
 		_table.insert_translation(vm_addr, phys_addr, size, pflags,
 		                          _table_array.alloc());
+		Kernel::Vm::invalidate_tlb_vm();
 		return;
 	} catch(Hw::Out_of_tables &) {
 		Genode::error("Translation table needs to much RAM");
@@ -63,7 +64,8 @@ void Vm_session_component::attach_pic(addr_t vm_addr)
 
 void Vm_session_component::_detach_vm_memory(addr_t vm_addr, size_t size)
 {
-	_table.remove_translation(vm_addr, size, _table_array.alloc());
+    _table.remove_translation(vm_addr, size, _table_array.alloc());
+    Kernel::Vm::invalidate_tlb_vm();
 }
 
 

--- a/repos/base-hw/src/core/spec/arm_v8/translation_table.h
+++ b/repos/base-hw/src/core/spec/arm_v8/translation_table.h
@@ -16,5 +16,12 @@
 
 /* core includes */
 #include <hw/spec/arm/lpae.h>
+#include <cpu.h>
+
+
+template <unsigned BLOCK_SIZE_LOG2, unsigned SZ_LOG2>
+void Hw::Long_translation_table<BLOCK_SIZE_LOG2, SZ_LOG2>::_update_cache(unsigned long addr, unsigned long size) {
+    Genode::Cpu::cache_coherent_region(addr, size);
+}
 
 #endif /* _CORE__SPEC__ARM_V8__TRANSLATION_TABLE_H_ */

--- a/repos/base-hw/src/core/spec/arm_v8/virtualization/exception_vector.s
+++ b/repos/base-hw/src/core/spec/arm_v8/virtualization/exception_vector.s
@@ -41,6 +41,11 @@ _host_to_vm:
 
 	msr vttbr_el2, x3   /* stage2 table pointer was arg3 */
 
+    adr x5, .           /* store return adress of _flush_tlb_vm */
+    add x5, x5, #16
+	cmp x4, #1          /* arg4 is invalidation flag of vm tlb */
+	beq _flush_tlb_vm
+
 	add  x0, x0, #31*8  /* skip x0...x30, loaded later */
 
 	ldr  x1,      [x0], #1*8  /* sp         */
@@ -363,7 +368,12 @@ _vm_to_host:
 
 	eret
 
+_flush_tlb_vm:
+    tlbi alle1					/* this should be done respective to the VMID */
+    br x5               /* return to _host_to_vm */
+
 /* host kernel must jump to this point to switch to a vm */
 .global hypervisor_enter_vm
 hypervisor_enter_vm:
 	hvc #0
+

--- a/repos/base/include/vm_session/connection.h
+++ b/repos/base/include/vm_session/connection.h
@@ -33,7 +33,7 @@ struct Genode::Vm_connection : Connection<Vm_session>, Vm_session_client
 	                                unsigned long affinity)
 	{
 		return session(parent,
-		               "priority=0x%lx, affinity=0x%lx, ram_quota=16K, cap_quota=10, label=\"%s\"",
+		               "priority=0x%lx, affinity=0x%lx, ram_quota=16M, cap_quota=800, label=\"%s\"",
 		               priority, affinity, label);
 	}
 

--- a/repos/os/run/vmm_arm.run
+++ b/repos/os/run/vmm_arm.run
@@ -61,8 +61,8 @@ install_config {
 		<resource name="RAM" quantum="1M"/>
 		<provides> <service name="Terminal"/> </provides>
 	</start>
-	<start name="vmm" caps="200" priority="-1">
-		<resource name="RAM" quantum="256M"/>
+	<start name="vmm" caps="1000" priority="-1">
+		<resource name="RAM" quantum="512M"/>
 		<route>
 			<service name="Terminal" label="earlycon"> <child name="log_terminal"/> </service>
 			<service name="Terminal"> <child name="terminal_crosslink"/> </service>
@@ -73,7 +73,7 @@ install_config {
 	<start name="vm">
 		<binary name="test-terminal_expect_send"/>
 		<resource name="RAM" quantum="1M"/>
-		<config expect="/ #" send="ls" verbose="yes"/>
+		<config expect="/ #" send="sleep 1" verbose="yes"/>
 		<route>
 			<service name="Terminal"> <child name="terminal_crosslink"/> </service>
 			<any-service><parent/><any-child/></any-service>

--- a/repos/os/src/server/vmm/spec/arm_v8/cpu.cc
+++ b/repos/os/src/server/vmm/spec/arm_v8/cpu.cc
@@ -17,6 +17,7 @@
 using Vmm::Cpu;
 using Vmm::Gic;
 
+
 Genode::Lock & Vmm::lock() { static Genode::Lock l {}; return l; }
 
 
@@ -223,6 +224,9 @@ void Cpu::_handle_sync()
 	case Esr::Ec::BRK:
 		_handle_brk();
 		return;
+    case 0x20: //instruction abort
+        _tester.attach_page(_state.hpfar_el2 << 8);
+        return;
 	default:
 		throw Exception("Unknown trap: %x",
 		                Esr::Ec::get(_state.esr_el2));
@@ -272,8 +276,13 @@ void Cpu::_handle_hyper_call()
 
 void Cpu::_handle_data_abort()
 {
-	_vm.bus().handle_memory_access(*this);
-	_state.ip += sizeof(Genode::uint32_t);
+    Genode::addr_t ipa = ((Genode::addr_t)_state.hpfar_el2 << 8);
+    if (BASE_RAM -1 < ipa && ipa < BASE_RAM + SZ_RAM) {
+        _tester.attach_page(ipa);
+    } else {
+        _vm.bus().handle_memory_access(*this);
+        _state.ip += sizeof(Genode::uint32_t);
+    }
 }
 
 
@@ -355,7 +364,8 @@ Cpu::Cpu(Vm                      & vm,
          Gic                     & gic,
          Genode::Env             & env,
          Genode::Heap            & heap,
-         Genode::Entrypoint      & ep)
+         Genode::Entrypoint      & ep,
+         Tester                  & tester)
 : _vm(vm),
   _vm_session(vm_session),
   _heap(heap),
@@ -396,7 +406,8 @@ Cpu::Cpu(Vm                      & vm,
   _sr_oslar           (2, 1, 0, 0, 4, "OSLAR_EL1",        true,  0x0, _reg_tree),
   _sr_sgi1r_el1       (_reg_tree, vm),
   _gic(*this, gic, bus),
-  _timer(env, ep, _gic.irq(27), *this)
+  _timer(env, ep, _gic.irq(27), *this),
+  _tester(tester)
 {
 	_state.pstate     = 0b1111000101; /* el1 mode and IRQs disabled */
 	_state.vmpidr_el2 = cpu_id();

--- a/repos/os/src/server/vmm/spec/arm_v8/cpu.h
+++ b/repos/os/src/server/vmm/spec/arm_v8/cpu.h
@@ -16,6 +16,7 @@
 
 #include <exception.h>
 #include <generic_timer.h>
+#include <tester.h>
 
 #include <base/env.h>
 #include <base/heap.h>
@@ -26,7 +27,8 @@
 namespace Vmm {
 	class Vm;
 	class Cpu;
-	Genode::Lock & lock();
+	class Tester;
+    Genode::Lock & lock();
 }
 
 class Vmm::Cpu
@@ -55,7 +57,8 @@ class Vmm::Cpu
 		    Gic                     & gic,
 		    Genode::Env             & env,
 		    Genode::Heap            & heap,
-		    Genode::Entrypoint      & ep);
+		    Genode::Entrypoint      & ep,
+            Tester                  & tester);
 
 		unsigned           cpu_id() const;
 		void               run();
@@ -314,6 +317,7 @@ class Vmm::Cpu
 		Icc_sgi1r_el1                     _sr_sgi1r_el1;
 		Gic::Gicd_banked                  _gic;
 		Generic_timer                     _timer;
+        Tester                          & _tester;
 
 		void _handle_nothing() {}
 		bool _handle_sys_reg();

--- a/repos/os/src/server/vmm/spec/arm_v8/target.mk
+++ b/repos/os/src/server/vmm/spec/arm_v8/target.mk
@@ -10,6 +10,7 @@ SRC_CC   += mmio.cc
 SRC_CC   += pl011.cc
 SRC_CC   += virtio_device.cc
 SRC_CC   += vm.cc
+SRC_CC   += tester.cc
 INC_DIR  += $(PRG_DIR)
 
 CC_CXX_WARN_STRICT :=

--- a/repos/os/src/server/vmm/spec/arm_v8/tester.cc
+++ b/repos/os/src/server/vmm/spec/arm_v8/tester.cc
@@ -1,0 +1,153 @@
+#include <tester.h>
+
+
+using Vmm::Tester;
+
+void Tester::attach_page(Genode::addr_t fault_addr) {
+
+    if (!_attach_pages) {
+        return;
+    }
+
+    Genode::uint64_t bm = ~(SZ_PAGE - 1);
+    fault_addr &= bm;
+    
+    Genode::uint64_t offset = fault_addr - BASE_RAM;
+    Genode::Vm_session::Attach_attr attr = {
+            .offset = offset,
+            .size = SZ_PAGE,
+            .writeable = true
+    };
+    _vm.attach(_vm_ram.cap(), BASE_RAM + offset, attr);
+
+    _page_attached[offset / SZ_PAGE] = true;
+    _num_attached_pages++;
+    if(_num_attached_pages > 9) {
+        _attach_remaining();
+    }
+}
+
+void Tester::_attach_remaining() {
+
+    Genode::Vm_session::Attach_attr attr = {
+            .offset = 0,
+            .size = SZ_PAGE,
+            .writeable = true
+    };
+
+    for (int i = 0; i < NUM_PAGES; i++) {
+        if (!_page_attached[i]) {
+            attr.offset = i * SZ_PAGE;
+            _vm.attach(_vm_ram.cap(), BASE_RAM + attr.offset, attr);
+            _page_attached[i] = true;
+        }
+    }
+
+    _rdy_for_test = true;
+    _num_attached_pages = NUM_PAGES;
+    Genode::log("all pages attached");
+}
+
+void Tester::_detach_entirely () {
+
+    _vm.detach(BASE_RAM, SZ_RAM);
+    Genode::log("entire detach");
+}
+
+void Tester::_detach_individually() {
+
+    _rdy_for_test = false;
+    _num_attached_pages = 0;
+
+    for (int i = 0; i < NUM_PAGES; i++) {
+        _vm.detach(BASE_RAM + i*SZ_PAGE, SZ_PAGE);
+    }
+
+    Genode::log("individual detach");
+}
+
+void Tester::_prepare_test_env() {
+
+    if (!_rdy_for_test) {
+        _attach_remaining();
+    }
+
+    _rdy_for_test = false;
+    _num_attached_pages = 0;
+
+    for (int i = 0; i < NUM_PAGES; i++ ) {
+        _page_attached[i] = false;
+    }
+}
+
+void Tester::_start_test(Genode::Duration) {
+
+    _cpu.pause();
+    _prepare_test_env();
+
+
+    /* Test 1: (1) detach entire guest ram,
+     *             this causes constant page faults,
+     *             the VM should not work anymore
+     *         */
+    if (TEST_CASE == 1) {
+        Genode::log("Start test 1");
+        _detach_entirely();
+        _attach_pages = false;
+    }
+
+    /* Test 2: (1) detach entire guest ram,
+     *         (2) attach single page on fault
+     *         (3) after 10 pages are attached, attach rest
+     *         */
+    if (TEST_CASE == 2) {
+        Genode::log("Start test 2");
+        _detach_entirely();
+        _attach_pages = true;
+        _timeout.schedule(Genode::Microseconds(FIVE_SECS));
+    }
+
+    /* Test 3: (1) detach guest ram page by page,
+     *             this causes constant page faults,
+     *             the VM should not work anymore
+     *         */
+    if (TEST_CASE == 3) {
+        Genode::log("Start test 3");
+        _detach_individually();
+        _attach_pages = false;
+    }
+
+
+    /* Test 4: (1) detach all pages individually,
+     *         (2) attach single page on fault
+     *         (3) after 10 pages are attached, attach rest
+     *         */
+
+    if (TEST_CASE == 4) {
+        Genode::log("Start test 4");
+        _detach_individually();
+        _attach_pages = true;
+        _timeout.schedule(Genode::Microseconds(FIVE_SECS));
+    }
+
+    /* Test 5-8: (1) set USE_SUPERPAGES to 0,
+     *           (2) rerun tests 1-4
+     *         */
+
+    _cpu.run();
+
+}
+
+
+Tester::Tester (Genode::Env & env,
+                Genode::Vm_connection & vm,
+                Cpu & cpu,
+                Genode::Attached_ram_dataspace & vm_ram)
+        :    _env(env),
+             _vm(vm),
+             _cpu(cpu),
+             _vm_ram(vm_ram),
+             _timeout(_timer, *this, &Tester::_start_test)
+{
+    _timeout.schedule(Genode::Microseconds(FIVE_SECS));
+}

--- a/repos/os/src/server/vmm/spec/arm_v8/tester.h
+++ b/repos/os/src/server/vmm/spec/arm_v8/tester.h
@@ -1,0 +1,72 @@
+/*
+ * \brief  testing cache-maintenance of page-table updates
+ * \author Chris hofer
+ */
+
+
+#ifndef _SRC__SERVER__VMM__TESTER_H_
+#define _SRC__SERVER__VMM__TESTER_H_
+
+#include <base/env.h>
+#include <base/attached_ram_dataspace.h>
+#include <vm_session/connection.h>
+#include <timer_session/connection.h>
+
+#include <cpu.h>
+
+
+#define BASE_RAM 0x40000000
+#define SZ_RAM (128 * 1024 *1024)
+#define USE_SUPERPAGES 1
+
+#if USE_SUPERPAGES
+#define SZ_PAGE 0x200000
+#else
+#define SZ_PAGE 0x1000
+#endif
+
+#define FIVE_SECS 5*1000*1000
+#define NUM_PAGES (SZ_RAM / SZ_PAGE)
+#define TEST_CASE 1
+
+namespace Vmm {
+    class Tester;
+}
+
+class Vmm::Tester {
+
+    private:
+        Genode::Env                     & _env;
+        Genode::Vm_connection           & _vm;
+        Cpu                             & _cpu;
+        Genode::Attached_ram_dataspace  & _vm_ram;
+
+        Timer::Connection                _timer { _env };
+        Timer::One_shot_timeout<Tester>  _timeout;
+
+        bool _rdy_for_test { true };
+
+        bool _attach_pages { false };
+        int  _num_attached_pages;
+        bool _page_attached[NUM_PAGES];
+
+        void _attach_remaining();
+        void _start_test(Genode::Duration);
+        void _detach_entirely();
+        void _detach_individually();
+
+        void _prepare_test_env();
+
+    public:
+        Tester (Genode::Env    & env,
+                Genode::Vm_connection      & vm,
+                Cpu & cpu,
+                Genode::Attached_ram_dataspace & vm_ram);
+
+        void attach_page(Genode::addr_t);
+
+
+
+};
+
+#endif /* _SRC__SERVER__VMM__TESTER_H_ */

--- a/repos/os/src/server/vmm/spec/arm_v8/virt.dts
+++ b/repos/os/src/server/vmm/spec/arm_v8/virt.dts
@@ -45,8 +45,8 @@
 	};
 
 	chosen {
-		/* bootargs = "rdinit=/bin/sh console=hvc0 earlycon=pl011,0x9000000"; */
-		bootargs = "init=/sbin/init ip=dhcp console=hvc0";
+		bootargs = "rdinit=/bin/sh console=hvc0 earlycon=pl011,0x9000000";
+		/* bootargs = "init=/sbin/init ip=dhcp console=hvc0"; */
 		linux,initrd-start = <0x42000000>;
 		linux,initrd-end   = <0x420aa539>;
 		stdout-path = "/pl011@9000000";

--- a/repos/os/src/server/vmm/spec/arm_v8/vm.cc
+++ b/repos/os/src/server/vmm/spec/arm_v8/vm.cc
@@ -41,7 +41,7 @@ void Vm::_load_initrd()
 Vmm::Cpu & Vm::boot_cpu()
 {
 	if (!_cpus[0].constructed())
-		_cpus[0].construct(*this, _vm, _bus, _gic, _env, _heap, _env.ep());
+		_cpus[0].construct(*this, _vm, _bus, _gic, _env, _heap, _env.ep(), _tester);
 	return *_cpus[0];
 }
 
@@ -51,8 +51,10 @@ Vm::Vm(Genode::Env & env)
   _gic("Gicv3", 0x8000000, 0x10000, _bus, env),
   _uart("Pl011", 0x9000000, 0x1000, 33, boot_cpu(), _bus, env),
   _virtio_console("HVC", 0xa000000, 0x200,  48, boot_cpu(), _bus, _ram, env),
-  _virtio_net("Net", 0xa000200, 0x200,  49, boot_cpu(), _bus, _ram, env)
+  _virtio_net("Net", 0xa000200, 0x200,  49, boot_cpu(), _bus, _ram, env),
+  _tester(env, _vm, boot_cpu(), _vm_ram)
 {
+    
 	_vm.attach(_vm_ram.cap(), RAM_ADDRESS);
 
 	/* FIXME extend for gicv2 by: _vm.attach_pic(0x8010000); */
@@ -65,7 +67,7 @@ Vm::Vm(Genode::Env & env)
 		Genode::Affinity::Space space = _env.cpu().affinity_space();
 		Genode::Affinity::Location location(space.location_of_index(i));
 		_eps[i].construct(_env, STACK_SIZE, "vcpu ep", location);
-		_cpus[i].construct(*this, _vm, _bus, _gic, _env, _heap, *_eps[i]);
+		_cpus[i].construct(*this, _vm, _bus, _gic, _env, _heap, *_eps[i], _tester);
 	}
 
 	Genode::log("Start virtual machine ...");

--- a/repos/os/src/server/vmm/spec/arm_v8/vm.h
+++ b/repos/os/src/server/vmm/spec/arm_v8/vm.h
@@ -21,6 +21,7 @@
 #include <pl011.h>
 #include <virtio_console.h>
 #include <virtio_net.h>
+#include <tester.h>
 
 #include <base/attached_ram_dataspace.h>
 #include <base/attached_rom_dataspace.h>
@@ -61,8 +62,10 @@ class Vmm::Vm
 		Pl011                          _uart;
 		Virtio_console                 _virtio_console;
 		Virtio_net                     _virtio_net;
+		Tester                         _tester;
 
-		void _load_kernel();
+
+        void _load_kernel();
 		void _load_dtb();
 		void _load_initrd();
 


### PR DESCRIPTION
Hi,

for my thesis-project, I extensively make use of the dataspace attachment/detachment API of the VM-session. I discovered that there are two issues when updating the stage-2 translation for a VM:

- when attaching a dataspace to a VM, the updates made to the S2-translation do not reliably reach the point-of-unification. This causes the VM to use the old S2-translations.
-  when detaching a dataspace of a VM, its TLB entries are not invalidated. Hence, VM accesses to the detached dataspace still remain valid.

Fix:
As for the first issue, I added in the lpae-page-table calls to base-hw for cache maintenance on the updated table/block descriptors.

To address the second issue, after updates to the S2-translation, the TLB entries of the VM are invalidated. This is currently done by a global flag passed to the world-switcher, which enforces the
invalidation of all TLB entries. However, it would be better to invalidate only the entries tagged with the VMID of the respective VM. I could not manage to build an easy kernel API for this though.

Implications:
- Cache maintenance is done in page-table class and hence also for other components.
- TLB invalidation affects all TLB entries, also those unrelated to the VM.

Notes:
The first commit are only tests. The second is the actual fix. I also pushed my actual working history on [this](https://github.com/zeehha/genode/tree/cache_tlb_fix_dirty) branch (it contains some additional but unnecessary tests too).

Best regards and stay safe,
Chris

Fixes #3726