### PR TITLE
run: Use Qemu 5.0.0 compatile gic-version param.

### DIFF
--- a/tool/run/power_on/qemu
+++ b/tool/run/power_on/qemu
@@ -112,7 +112,7 @@ proc run_power_on { } {
 	if {[have_spec virt_qemu]} {
 		append qemu_args " -M virt,virtualization=true"
 		if {[have_spec arm_v8a]} {
-			append qemu_args ",gic_version=3 -cpu cortex-a53 -smp 4"
+			append qemu_args ",gic-version=3 -cpu cortex-a53 -smp 4"
 		}
 		if {[have_spec arm_v7a]} {
 			append qemu_args " -cpu cortex-a15 -smp 2"


### PR DESCRIPTION
It seems Qemu 5.0.0 no longer supports gic_version parameter.
Apparently this only worked due to some compat feature that
was dropped in Qemu 5.0.0. The replacement which works on both
old and new Qemu versions is gic-version.