### PR TITLE
platform_session: Add missing include.

### DIFF
--- a/repos/os/include/spec/arm/platform_session/connection.h
+++ b/repos/os/include/spec/arm/platform_session/connection.h
@@ -14,6 +14,7 @@
 #ifndef _INCLUDE__SPEC__ARM__PLATFORM_SESSION__CONNECTION_H_
 #define _INCLUDE__SPEC__ARM__PLATFORM_SESSION__CONNECTION_H_
 
+#include <base/attached_dataspace.h>
 #include <base/connection.h>
 #include <base/env.h>
 #include <platform_session/client.h>


### PR DESCRIPTION
The code uses Genode::Attached_dataspace but fails to include header
declaring this type.