### PR TITLE
Xml_generator: Remove unused _has_attributes member variable.

### DIFF
--- a/repos/base/include/util/xml_generator.h
+++ b/repos/base/include/util/xml_generator.h
@@ -172,7 +172,6 @@ class Genode::Xml_generator
 
 				bool _has_content    = false;
 				bool _is_indented    = false;
-				bool _has_attributes = false;
 
 				/**
 				 * Cursor position of next attribute to insert


### PR DESCRIPTION
This triggers a warning when building the code with clang.