### PR TITLE
A collection of fixes and cleanups for issue reported by clang 11

### DIFF
--- a/repos/base-hw/src/bootstrap/platform.cc
+++ b/repos/base-hw/src/bootstrap/platform.cc
@@ -150,9 +150,8 @@ Mapping Platform::_load_elf()
 
 void Platform::start_core(unsigned cpu_id)
 {
-	typedef void (* Entry)(unsigned);
-	Entry __attribute__((noreturn)) const entry
-		= reinterpret_cast<Entry>(core_elf.entry());
+	typedef void (* Entry)(unsigned) __attribute__((noreturn));
+	Entry const entry = reinterpret_cast<Entry>(core_elf.entry());
 	entry(cpu_id);
 }
 

--- a/repos/base-hw/src/core/spec/arm/virtualization/vm_session_component.cc
+++ b/repos/base-hw/src/core/spec/arm/virtualization/vm_session_component.cc
@@ -95,7 +95,7 @@ Vm_session_component::Vm_session_component(Rpc_entrypoint &ds_ep,
   _sliced_heap(_constrained_md_ram_alloc, region_map),
   _region_map(region_map),
   _table(*construct_at<Board::Vm_page_table>(_alloc_table())),
-  _table_array(*(new (cma()) Board::Vm_page_table_array([this] (void * virt) {
+  _table_array(*(new (cma()) Board::Vm_page_table_array([] (void * virt) {
 	return (addr_t)cma().phys_addr(virt);})))
 {
 	/* configure managed VM area */

--- a/repos/base-hw/src/core/spec/arm_v8/kernel/thread.cc
+++ b/repos/base-hw/src/core/spec/arm_v8/kernel/thread.cc
@@ -28,13 +28,13 @@ void Thread::exception(Cpu & cpu)
 {
 	switch (regs->exception_type) {
 	case Cpu::RESET:         return;
-	case Cpu::IRQ_LEVEL_EL0: [[fallthrough]]
-	case Cpu::IRQ_LEVEL_EL1: [[fallthrough]]
-	case Cpu::FIQ_LEVEL_EL0: [[fallthrough]]
+	case Cpu::IRQ_LEVEL_EL0: [[fallthrough]];
+	case Cpu::IRQ_LEVEL_EL1: [[fallthrough]];
+	case Cpu::FIQ_LEVEL_EL0: [[fallthrough]];
 	case Cpu::FIQ_LEVEL_EL1:
 		_interrupt(cpu.id());
 		return;
-	case Cpu::SYNC_LEVEL_EL0: [[fallthrough]]
+	case Cpu::SYNC_LEVEL_EL0: [[fallthrough]];
 	case Cpu::SYNC_LEVEL_EL1:
 		{
 			Cpu::Esr::access_t esr = Cpu::Esr_el1::read();

--- a/repos/base-hw/src/core/spec/arm_v8/virtualization/kernel/vm.cc
+++ b/repos/base-hw/src/core/spec/arm_v8/virtualization/kernel/vm.cc
@@ -163,15 +163,15 @@ Vm::~Vm() { alloc().free(_id); }
 void Vm::exception(Cpu & cpu)
 {
 	switch (_state.exception_type) {
-	case Cpu::IRQ_LEVEL_EL0: [[fallthrough]]
-	case Cpu::IRQ_LEVEL_EL1: [[fallthrough]]
-	case Cpu::FIQ_LEVEL_EL0: [[fallthrough]]
+	case Cpu::IRQ_LEVEL_EL0: [[fallthrough]];
+	case Cpu::IRQ_LEVEL_EL1: [[fallthrough]];
+	case Cpu::FIQ_LEVEL_EL0: [[fallthrough]];
 	case Cpu::FIQ_LEVEL_EL1:
 		_interrupt(cpu.id());
 		break;
-	case Cpu::SYNC_LEVEL_EL0: [[fallthrough]]
-	case Cpu::SYNC_LEVEL_EL1: [[fallthrough]]
-	case Cpu::SERR_LEVEL_EL0: [[fallthrough]]
+	case Cpu::SYNC_LEVEL_EL0: [[fallthrough]];
+	case Cpu::SYNC_LEVEL_EL1: [[fallthrough]];
+	case Cpu::SERR_LEVEL_EL0: [[fallthrough]];
 	case Cpu::SERR_LEVEL_EL1:
 		pause();
 		_context.submit(1);

--- a/repos/base-linux/src/core/include/io_mem_session_component.h
+++ b/repos/base-linux/src/core/include/io_mem_session_component.h
@@ -29,9 +29,7 @@ namespace Genode {
 
 		private:
 
-			Range_allocator &_io_mem_alloc;
 			Dataspace_component _ds;
-			Rpc_entrypoint &_ds_ep;
 			Io_mem_dataspace_capability _ds_cap;
 
 			size_t get_arg_size(const char *);

--- a/repos/base-linux/src/core/include/irq_object.h
+++ b/repos/base-linux/src/core/include/irq_object.h
@@ -29,8 +29,6 @@ class Genode::Irq_object : public Thread_deprecated<4096>
 		Genode::Signal_context_capability _sig_cap;
 		Genode::Blockade _sync_ack { };
 		Genode::Blockade _sync_bootup { };
-		unsigned const _irq;
-		int _fd;
 
 		bool _associate();
 
@@ -38,7 +36,7 @@ class Genode::Irq_object : public Thread_deprecated<4096>
 
 	public:
 
-		Irq_object(unsigned irq);
+		Irq_object();
 		void sigh(Signal_context_capability cap);
 		void ack_irq();
 

--- a/repos/base-linux/src/core/include/native_pd_component.h
+++ b/repos/base-linux/src/core/include/native_pd_component.h
@@ -34,10 +34,7 @@ class Genode::Native_pd_component : public Rpc_object<Linux_native_pd,
 		enum { ROOT_PATH_MAX_LEN =  512 };
 
 		Pd_session_component &_pd_session;
-		char                  _root[ROOT_PATH_MAX_LEN];
 		unsigned long         _pid = 0;
-		unsigned              _uid = 0;
-		unsigned              _gid = 0;
 
 		void _start(Dataspace_component &ds);
 

--- a/repos/base-linux/src/core/spec/linux/io_mem_session_component.cc
+++ b/repos/base-linux/src/core/spec/linux/io_mem_session_component.cc
@@ -39,12 +39,13 @@ Io_mem_session_component::Io_mem_session_component(Range_allocator &io_mem_alloc
                                                    Range_allocator &,
                                                    Rpc_entrypoint  &ds_ep,
                                                    const char      *args) :
-    _io_mem_alloc(io_mem_alloc),
     _ds(0, 0, 0, UNCACHED, true, 0),
-    _ds_ep(ds_ep),
     _ds_cap(Io_mem_dataspace_capability())
 {
-	warning("no io_mem support on Linux (args=\"", args, "\")"); }
+	(void)io_mem_alloc;
+	(void)ds_ep;
+	warning("no io_mem support on Linux (args=\"", args, "\")");
+}
 
 Cache_attribute Io_mem_session_component::get_arg_wc(const char *)
 {

--- a/repos/base-linux/src/core/spec/linux/irq_session_component.cc
+++ b/repos/base-linux/src/core/spec/linux/irq_session_component.cc
@@ -23,7 +23,7 @@
 Genode::Irq_session_component::Irq_session_component(Genode::Range_allocator &, const char *)
 :
 	_irq_number(0),
-	_irq_object(_irq_number)
+	_irq_object()
 { }
 
 Genode::Irq_session_component::~Irq_session_component()
@@ -42,11 +42,9 @@ Genode::Irq_session::Info Genode::Irq_session_component::info()
 	return { .type = Genode::Irq_session::Info::Type::INVALID, .address = 0, .value = 0 };
 }
 
-Genode::Irq_object::Irq_object(unsigned irq) :
+Genode::Irq_object::Irq_object() :
 	Thread_deprecated<4096>("irq"),
-	_sig_cap(Signal_context_capability()),
-	_irq(irq),
-	_fd(-1)
+	_sig_cap(Signal_context_capability())
 {
     Genode::warning(__func__, " not implemented");
 }

--- a/repos/base-linux/src/lib/base/ipc.cc
+++ b/repos/base-linux/src/lib/base/ipc.cc
@@ -114,7 +114,6 @@ namespace {
 			typedef Genode::size_t size_t;
 
 			msghdr      _msg   { };
-			sockaddr_un _addr  { };
 			iovec       _iovec { };
 			char        _cmsg_buf[CMSG_SPACE(MAX_SDS_PER_MSG*sizeof(int))];
 

--- a/repos/base/include/base/rpc_args.h
+++ b/repos/base/include/base/rpc_args.h
@@ -97,6 +97,9 @@ class Genode::Rpc_in_buffer : public Rpc_in_buffer_base
 		 */
 		Rpc_in_buffer() { }
 
+		Rpc_in_buffer(const Rpc_in_buffer &in)
+		: Rpc_in_buffer_base(in.base(), in.size()) { }
+
 		Rpc_in_buffer &operator = (Rpc_in_buffer<MAX_SIZE> const &from)
 		{
 			_base = from.base();

--- a/repos/base/src/core/include/cpu_root.h
+++ b/repos/base/src/core/include/cpu_root.h
@@ -30,7 +30,6 @@ namespace Genode {
 			Region_map             &_local_rm;
 			Rpc_entrypoint         &_thread_ep;
 			Pager_entrypoint       &_pager_ep;
-			Allocator              &_md_alloc;
 			Trace::Source_registry &_trace_sources;
 
 		protected:
@@ -80,7 +79,7 @@ namespace Genode {
 				Root_component<Cpu_session_component>(&session_ep, &md_alloc),
 				_ram_alloc(ram_alloc), _local_rm(local_rm),
 				_thread_ep(thread_ep), _pager_ep(pager_ep),
-				_md_alloc(md_alloc), _trace_sources(trace_sources)
+				_trace_sources(trace_sources)
 			{ }
 	};
 }

--- a/repos/base/src/core/include/trace/subject_registry.h
+++ b/repos/base/src/core/include/trace/subject_registry.h
@@ -309,7 +309,6 @@ class Genode::Trace::Subject_registry
 		typedef List<Subject> Subjects;
 
 		Allocator       &_md_alloc;
-		Ram_allocator   &_ram;
 		Source_registry &_sources;
 		unsigned         _id_cnt  { 0 };
 		Mutex            _mutex   { };
@@ -396,10 +395,10 @@ class Genode::Trace::Subject_registry
 		 * \param ram       allocator used for the allocation of trace
 		 *                  buffers and policy dataspaces.
 		 */
-		Subject_registry(Allocator &md_alloc, Ram_allocator &ram,
+		Subject_registry(Allocator &md_alloc,
 		                 Source_registry &sources)
 		:
-			_md_alloc(md_alloc), _ram(ram), _sources(sources)
+			_md_alloc(md_alloc), _sources(sources)
 		{ }
 
 		/**

--- a/repos/base/src/core/region_map_component.cc
+++ b/repos/base/src/core/region_map_component.cc
@@ -24,7 +24,6 @@
 #include <region_map_component.h>
 #include <dataspace_component.h>
 
-static const bool verbose             = false;
 static const bool verbose_page_faults = false;
 
 

--- a/repos/base/src/core/trace_session_component.cc
+++ b/repos/base/src/core/trace_session_component.cc
@@ -185,7 +185,7 @@ Session_component::Session_component(Rpc_entrypoint  &ep,
 	_parent_levels(parent_levels),
 	_sources(sources),
 	_policies(policies),
-	_subjects(_subjects_slab, _ram, _sources),
+	_subjects(_subjects_slab, _sources),
 	_argument_buffer(_ram, local_rm, arg_buffer_size)
 { }
 

--- a/repos/base/src/lib/cxx/new_delete.cc
+++ b/repos/base/src/lib/cxx/new_delete.cc
@@ -67,7 +67,7 @@ void operator delete (void *ptr, Deallocator &dealloc) { try_dealloc(ptr,  deall
  * implementation of the 'stdcxx' library instead. To make this possible, the
  * 'delete (void *)' implementation in the 'cxx' library must be 'weak'.
  */
-__attribute__((weak)) void operator delete (void *)
+__attribute__((weak)) void operator delete (void *) noexcept
 {
 	Genode::error("cxx: operator delete (void *) called - not implemented. "
 	              "A working implementation is available in the 'stdcxx' library.");

--- a/repos/base/src/lib/startup/init_main_thread.cc
+++ b/repos/base/src/lib/startup/init_main_thread.cc
@@ -104,7 +104,7 @@ extern "C" void init_main_thread()
 	 * Explicitly setup program environment at this point to ensure that its
 	 * destructor won't be registered for the atexit routine.
 	 */
-	(void*)env_deprecated();
+	(void)env_deprecated();
 	init_log(*env_deprecated()->parent());
 
 	/* create a thread object for the main thread */

--- a/repos/os/src/app/ping/main.cc
+++ b/repos/os/src/app/ping/main.cc
@@ -70,7 +70,6 @@ class Main : public Nic_handler,
 		Net::Nic                        _nic           { _env, _heap, *this, _verbose };
 		Ipv4_address             const  _dst_ip        { _config.attribute_value("dst_ip",  Ipv4_address()) };
 		Mac_address                     _dst_mac       { };
-		uint16_t                        _ip_id         { 1 };
 		uint16_t                        _icmp_seq      { 1 };
 		unsigned long                   _count         { _config.attribute_value("count", (unsigned long)DEFAULT_COUNT) };
 		Constructible<Dhcp_client>      _dhcp_client   { };

--- a/repos/os/src/drivers/platform/imx8mq/ccm.h
+++ b/repos/os/src/drivers/platform/imx8mq/ccm.h
@@ -173,7 +173,6 @@ struct Driver::Ccm
 
 
 		Clock      & _parent;
-		Clock_tree & _tree;
 
 		public:
 
@@ -182,7 +181,7 @@ struct Driver::Ccm
 			                   Clock       & parent,
 			                   Clock_tree  & tree)
 			: Clock(name, tree), Mmio(base),
-			  _parent(parent), _tree(tree) {}
+			  _parent(parent) {}
 
 			void          set_rate(unsigned long) override;
 			unsigned long get_rate()        const override;

--- a/repos/os/src/drivers/virtdev_rom/main.cc
+++ b/repos/os/src/drivers/virtdev_rom/main.cc
@@ -62,7 +62,6 @@ class Virtdev_rom::Root : public Root_component<Session_component>
 		Root(Root const &) = delete;
 		Root &operator = (Root const &) = delete;
 
-		Env                      &_env;
 		Ram_dataspace_capability  _ds;
 
 		Session_component *_create_session(const char *) override
@@ -75,9 +74,7 @@ class Virtdev_rom::Root : public Root_component<Session_component>
 	public:
 
 		Root(Env &env, Allocator &md_alloc, Ram_dataspace_capability &cap)
-		: Root_component<Session_component>(env.ep(), md_alloc),
-		  _env(env),
-		  _ds(cap)
+		: Root_component<Session_component>(env.ep(), md_alloc), _ds(cap)
 		{ }
 };
 

--- a/repos/os/src/lib/sandbox/child_registry.h
+++ b/repos/os/src/lib/sandbox/child_registry.h
@@ -32,7 +32,7 @@ class Sandbox::Child_registry : public Name_registry, Child_list
 		bool _unique(const char *name) const
 		{
 			/* check for name clash with an existing child */
-			List_element<Sandbox::Child> const *curr = first();
+			List_element<Child> const *curr = first();
 			for (; curr; curr = curr->next())
 				if (curr->object()->has_name(name))
 					return false;

--- a/repos/os/src/lib/sandbox/types.h
+++ b/repos/os/src/lib/sandbox/types.h
@@ -28,7 +28,7 @@ namespace Sandbox {
 
 	struct Prio_levels { long value; };
 
-	typedef List<List_element<Sandbox::Child> > Child_list;
+	typedef List<List_element<Child> > Child_list;
 }
 
 #endif /* _LIB__SANDBOX__TYPES_H_ */


### PR DESCRIPTION
This patch series contains a small collection of fixes and cleanups for various problems reported by clang 11. All of the issues fixed here are pretty generic. At least some of the issues fixed here can also be reproduced when building Genode with GCC 10.
