### PR TITLE
base-linux: Drop parentheses from .cfi_undefined.

### DIFF
--- a/repos/base-linux/src/lib/syscall/spec/x86_64/lx_clone.S
+++ b/repos/base-linux/src/lib/syscall/spec/x86_64/lx_clone.S
@@ -50,7 +50,7 @@ L(pseudo_end):
 L(thread_start):
 	.cfi_startproc
 	/* Clearing frame pointer is insufficient, use CFI.  */
-	.cfi_undefined (%rip);
+	.cfi_undefined %rip;
 
 	/* Clear the frame pointer.  The ABI suggests this be done, to mark 
 	   the outermost frame obviously.  */


### PR DESCRIPTION
According to GNU as manual the syntax of this directive is:
  .cfi_undefined register

The manual does not mention the register should be in parentheses.
This works in GNU as even when those are present, but unfortunately
clang integrated-as does not parse this correctly. Both GNU and
clang's integrated assembler work fine when the extra parentheses
are omitted.