### PR TITLE
base-hw: Fully define _crt0_start_stack value on arm_64

### DIFF
--- a/repos/base-hw/src/bootstrap/spec/arm_64/crt0.s
+++ b/repos/base-hw/src/bootstrap/spec/arm_64/crt0.s
@@ -92,4 +92,4 @@
 		.space STACK_SIZE
 	.endr
 	_crt0_start_stack:
-	.long STACK_SIZE
+	.quad STACK_SIZE


### PR DESCRIPTION
The _crt0_start_stack label points to a memory location containing the size of the bootstrap stack. On AArch64 this should be an 8 byte value, but the code only only defines half of those using asm .long statement. The other half is expected to be 0, which is true when using GNU as. This is not the case when using clang's integrated as however. Since _crt0_stack_size is defined inside .text section clang uses 0xd503201f value (aarch64 nop instruction) to fill the extra 4 bytes.

Fix this minor incompatibility by explicitly defining both halfs of this 8 byte quantity.