### PR TITLE
base: Explicitly mark read-only segment as r-x;

### DIFF
--- a/repos/base/src/ld/genode.ld
+++ b/repos/base/src/ld/genode.ld
@@ -15,8 +15,8 @@ ENTRY(_start)
 
 PHDRS
 {
-	ro PT_LOAD;
-	rw PT_LOAD;
+	ro PT_LOAD FLAGS(5);
+	rw PT_LOAD FLAGS(6);
 	boot PT_LOAD FLAGS(4);
 }
 


### PR DESCRIPTION
The code in base-hw/src/bootstrap/platform.cc uses segment flags to identify segments in order to decide what to do with them. Unfortunately the linker script does not actually ensure the flags for a specific named segment match expectations. The code relies on implicit linker behaviour. Unfortunately this implicit behaviour can vary between linkers. This for example breaks arm_v7a base-hw builds linked with LLVM's lld linker. The segment named "ro" ends up having writeable flag set when using LLD on arm_v7a.

This patch makes sure the "ro" segment has r-x permissions. With this in place LLD produces working binaries that are very similar to those produced by BFD.