### PR TITLE
Two minor fixes for sculpt 21.10

### DIFF
--- a/repos/base-linux/lib/mk/lx_hybrid.mk
+++ b/repos/base-linux/lib/mk/lx_hybrid.mk
@@ -2,6 +2,10 @@ SRC_CC += lx_hybrid.cc new_delete.cc capability_space.cc
 SRC_CC += signal_transmitter.cc signal.cc
 SRC_C  += libgcc.c
 
+# new_delete.cc uses libsupc++ which means we need to access
+# its include directory.
+STDINC := yes
+
 vpath new_delete.cc $(BASE_DIR)/src/lib/cxx
 vpath lx_hybrid.cc   $(REP_DIR)/src/lib/lx_hybrid
 vpath libgcc.c       $(REP_DIR)/src/lib/lx_hybrid

--- a/repos/base/include/util/reconstructible.h
+++ b/repos/base/include/util/reconstructible.h
@@ -45,7 +45,7 @@ Genode::Reconstructible : Noncopyable
 		/**
 		 * Static reservation of memory for the embedded object
 		 */
-		char _space[sizeof(MT)] alignas(sizeof(addr_t));
+		alignas(sizeof(addr_t)) char _space[sizeof(MT)];
 
 		/**
 		 * True if the volatile object contains a constructed object

--- a/repos/base/src/lib/cxx/new_delete.cc
+++ b/repos/base/src/lib/cxx/new_delete.cc
@@ -15,6 +15,8 @@
 #include <base/allocator.h>
 #include <base/sleep.h>
 
+#include <new>
+
 using Genode::size_t;
 using Genode::Allocator;
 using Genode::Deallocator;
@@ -84,5 +86,11 @@ __attribute__((weak)) void operator delete (void *, unsigned long)
 __attribute__((weak)) void operator delete (void *, unsigned long, std::align_val_t)
 {
 	Genode::error("cxx: operator delete (void *, unsigned long, std::align_val_t) called - not implemented. "
+	              "A working implementation is available in the 'stdcxx' library.");
+}
+
+__attribute__((weak)) void operator delete (void *, std::align_val_t) noexcept
+{
+	Genode::error("cxx: operator delete (void *, std::align_val_t) called - not implemented. "
 	              "A working implementation is available in the 'stdcxx' library.");
 }


### PR DESCRIPTION
First fix allows the code in reconstructible to be built with both gcc and clang.

Second one should result in potential runtime crash to be replaced with explicit error runtime message.