### PR TITLE
fix: use correct default value for nameserver

### DIFF
--- a/repos/libports/run/fetchurl.inc
+++ b/repos/libports/run/fetchurl.inc
@@ -137,11 +137,11 @@ install_config {
 				<dir name="dev">
 					<log/> <null/> <inline name="rtc">2000-01-01 00:00</inline>
 					<inline name="random">01234567890123456789</inline>
+					<dir name="socket"> } [socket_fs_plugin] { </dir>
 				</dir>
-				<dir name="socket"> } [socket_fs_plugin] { </dir>
 			</vfs>
 			<libc stdout="/dev/log" stderr="/dev/log" rtc="/dev/rtc"
-			      rng="/dev/random" socket="/socket"/>
+			      rng="/dev/random" socket="/dev/socket"/>
 			<fetch url="https://genode.org/about/LICENSE" path="/dev/log" retry="3"/>
 		</config>
 	</start>

--- a/repos/libports/src/lib/libc/vfs_plugin.cc
+++ b/repos/libports/src/lib/libc/vfs_plugin.cc
@@ -193,8 +193,11 @@ namespace Libc {
 	char const *config_nameserver_file() __attribute__((weak));
 	char const *config_nameserver_file()
 	{
+		static Genode::String<Vfs::MAX_PATH_LEN> default_value {
+			config_socket(), "/nameserver" };
+
 		static Config_attr ns_file("nameserver_file",
-		                           "/socket/nameserver");
+		                           default_value.string());
 		return ns_file.string();
 	}
 


### PR DESCRIPTION
 Currently, the default path for the `nameserver` file is fixed and it's `/socket/nameserver`. So, if the socket directory is not `/socket` DNS will not work (unless the user will manually set `nameserver` attribute). These changes fix this, now the default path for the `nameserver` takes into account the `socket` path. 

I have tested these changes with the `fetchurl` runscript on `base-nova`. The second commit has changes that demonstrate that.

Issue #4318