### PR TITLE
sntp_client.run: fix for unneeded packages

### DIFF
--- a/repos/libports/run/sntp_client.run
+++ b/repos/libports/run/sntp_client.run
@@ -106,7 +106,7 @@ append config {
 </config>}
 
 install_config $config
-build_boot_image { core ld.lib.so init timer sntp_client report_rom }
+build_boot_image { sntp_client report_rom }
 
 append qemu_args "  -nographic "
 append_qemu_nic_args


### PR DESCRIPTION
When I tried the run script the following error occured:
error copying "bin/init": no such file or directory

Looks like some packages are not needed to build the boot image and provoked the error.