### PR TITLE
base-linux: fix build (BOARD=pc)

### DIFF
--- a/repos/base-linux/src/core/spec/pc/dataspace_component.cc
+++ b/repos/base-linux/src/core/spec/pc/dataspace_component.cc
@@ -54,7 +54,7 @@ Linux_dataspace::Filename Dataspace_component::_file_name(const char *args)
 Genode::size_t Dataspace_component::_file_size()
 {
 	uint64_t size = 0;
-	if (lx_stat_size(_fname.buf, &size) < 0)
+	if (lx_stat_size(_fname.buf, size) < 0)
 		throw Service_denied();
 
 	return size;

--- a/repos/base-linux/src/core/spec/pc/io_port_session_component.cc
+++ b/repos/base-linux/src/core/spec/pc/io_port_session_component.cc
@@ -23,8 +23,8 @@ Io_port_session_component::Io_port_session_component(Range_allocator &io_port_al
 	_io_port_alloc(io_port_alloc)
 {
 	/* parse for port properties */
-	_base = Arg_string::find_arg(args, "io_port_base").ulong_value(0);
-	_size = Arg_string::find_arg(args, "io_port_size").ulong_value(0);
+	_base = (unsigned short)Arg_string::find_arg(args, "io_port_base").ulong_value(0);
+	_size = (unsigned short)Arg_string::find_arg(args, "io_port_size").ulong_value(0);
 }
 
 Io_port_session_component::~Io_port_session_component() { }

--- a/repos/base-linux/src/core/spec/pc/irq_session_component.cc
+++ b/repos/base-linux/src/core/spec/pc/irq_session_component.cc
@@ -26,7 +26,7 @@ using namespace Genode;
 
 Irq_session_component::Irq_session_component(Range_allocator &, const char *args)
 :
-	_irq_number(Arg_string::find_arg(args, "irq_number").long_value(-1)),
+	_irq_number((unsigned)Arg_string::find_arg(args, "irq_number").long_value(-1)),
 	_irq_object(_irq_number)
 {
 	_irq_object.start();


### PR DESCRIPTION
Fix a few build errors related to required type conversions
and handling of references.

Fixes #4440.