### PR TITLE
nic_router: multicast packet handling

### DIFF
--- a/repos/os/src/server/nic_router/interface.cc
+++ b/repos/os/src/server/nic_router/interface.cc
@@ -1293,9 +1293,13 @@ void Interface::_handle_ip(Ethernet_frame          &eth,
 	}
 	catch (Ip_rule_list::No_match) { }
 
-	/* give up and drop packet */
-	_send_icmp_dst_unreachable(local_intf, eth, ip,
-	                           Icmp_packet::Code::DST_NET_UNREACHABLE);
+	Ipv4_address_prefix const multicast_range(Ipv4_packet::ip_from_string("224.0.0.0"), 4);
+
+	/* give up and drop packet, only send icmp package if no multicast packet */
+	if(!(multicast_range.prefix_matches(ip.dst())))
+		_send_icmp_dst_unreachable(local_intf, eth, ip,
+		                           Icmp_packet::Code::DST_NET_UNREACHABLE);
+
 	if (_config().verbose()) {
 		log("[", local_domain, "] unroutable packet"); }
 }

--- a/repos/os/src/server/nic_router/ipv4_address_prefix.cc
+++ b/repos/os/src/server/nic_router/ipv4_address_prefix.cc
@@ -101,3 +101,9 @@ Ipv4_address_prefix::Ipv4_address_prefix(Ipv4_address address,
 	for (Genode::uint8_t mask = 1 << 7; rest & mask; mask >>= 1)
 		prefix++;
 }
+
+Ipv4_address_prefix::Ipv4_address_prefix(Ipv4_address address,
+                                         Genode::uint8_t prefix)
+:
+	address(address), prefix(prefix)
+{ }

--- a/repos/os/src/server/nic_router/ipv4_address_prefix.h
+++ b/repos/os/src/server/nic_router/ipv4_address_prefix.h
@@ -32,6 +32,9 @@ struct Net::Ipv4_address_prefix
 	Ipv4_address_prefix(Ipv4_address address,
 	                    Ipv4_address subnet_mask);
 
+	Ipv4_address_prefix(Ipv4_address address,
+	                    Genode::uint8_t prefix);
+
 	Ipv4_address_prefix() : prefix(32) { }
 
 	bool valid() const { return address.valid() || prefix == 0; }


### PR DESCRIPTION
Multicast packets will no more be handled with an ICMP 'destination unreachable' packet but discarded silently.

#4563 