### PR TITLE
audio_in_session: fix wrong buffer in content

### DIFF
--- a/repos/os/include/audio_in_session/audio_in_session.h
+++ b/repos/os/include/audio_in_session/audio_in_session.h
@@ -80,7 +80,7 @@ class Audio_in::Packet
 			Genode::memcpy(_data, data, (samples > PERIOD ? PERIOD : samples) * SAMPLE_SIZE);
 
 			if (samples < PERIOD)
-				Genode::memset(data + samples, 0, (PERIOD - samples) * SAMPLE_SIZE);
+				Genode::memset(_data + samples, 0, (PERIOD - samples) * SAMPLE_SIZE);
 		}
 
 		/**


### PR DESCRIPTION
When trying to fill the unspecified part of the packet content with zeroes, the memory behind the given data buffer is filled instead. This will lead to page faults in many circumstances.