### PR TITLE
Usb ctrl timeout jiffies

### DIFF
--- a/repos/dde_linux/src/lib/lx_emul/usb.c
+++ b/repos/dde_linux/src/lib/lx_emul/usb.c
@@ -23,6 +23,7 @@
 
 #include <lx_emul/shared_dma_buffer.h>
 #include <lx_emul/task.h>
+#include <lx_emul/time.h>
 #include <lx_user/init.h>
 #include <lx_user/io.h>
 
@@ -677,6 +678,7 @@ handle_urb_request(struct genode_usb_request_urb req,
 	if (ctrl && ctrl->timeout) {
 		context->timer_state = TIMER_ACTIVE;
 		timer_setup(&context->timeo, urb_timeout, 0);
+		lx_emul_force_jiffies_update();
 		mod_timer(&context->timeo, jiffies + msecs_to_jiffies(ctrl->timeout));
 	}
 


### PR DESCRIPTION
Sometimes urb timeouts on smart card readers (which were supposed to be 1 second) were triggered almost immediately. Sometimes, they were not triggered at all.
Forcing a jiffies update before using them (as described in a comment in clocksource.c) seems to solve this problem.