### PR TITLE
usb: fix wrong encoded device name

### DIFF
--- a/repos/os/include/usb/types.h
+++ b/repos/os/include/usb/types.h
@@ -56,18 +56,18 @@ namespace Usb {
 	};
 
 	/**
-	 * UTF-16 string
+	 * UTF-8 string
 	 */
-	typedef Genode::uint16_t utf16_t;
+	typedef Genode::uint8_t utf8_t;
 }
 
 
 /**
- * String containing UTF-16 plane 0 characters
+ * String containing UTF-8 characters
  */
 struct Usb::String
 {
-	utf16_t *string = nullptr;
+	utf8_t *string = nullptr;
 	unsigned length = 0;
 
 	void copy(unsigned len, void *from, Genode::Allocator *md_alloc)
@@ -77,8 +77,8 @@ struct Usb::String
 		if (len == 0)
 			return;
 
-		string = (utf16_t *)md_alloc->alloc(length * sizeof(utf16_t));
-		Genode::memcpy(string, from, sizeof(utf16_t) * length);
+		string = (utf8_t *)md_alloc->alloc(length * sizeof(utf8_t));
+		Genode::memcpy(string, from, sizeof(utf8_t) * length);
 	}
 
 	void free(Genode::Allocator *md_alloc)
@@ -86,7 +86,7 @@ struct Usb::String
 		if (!string)
 			return;
 
-		md_alloc->free(string, length * sizeof(utf16_t));
+		md_alloc->free(string, length * sizeof(utf8_t));
 		string = nullptr;
 	}
 


### PR DESCRIPTION
In the usb_block_drv the log message "Found USB device:" showed a broken manufacturer and product name.

With this fix the log message shows the correct device name. I also tested it with a raspberry pi 4 that played a usb mass storage device and set there a manufaturer and device name that contained characters that were outside of the ascii range, as I didn't find any device that provided such a name for testing. It looks like it works as expected.

I admit I haven't investigated a lot why the string is encoded in UTF-8 and not in UTF-16 as described in the USB Standard. I assume the driver receives the strings in some way via usb_string() [1] that returns the strings in UTF-8.

fixes #4756 

[1] https://www.kernel.org/doc/html/v6.1/driver-api/usb/usb.html?highlight#usb-core-apis