### PR TITLE
depot_download_manager: fix verifying failed download

### DIFF
--- a/repos/gems/src/app/depot_download_manager/import.h
+++ b/repos/gems/src/app/depot_download_manager/import.h
@@ -44,6 +44,10 @@ class Depot_download_manager::Import
 
 				bool complete() const
 				{
+					/* fetchurl did not return valid download info */
+					if (total == "")
+						return false;
+
 					/* fetchurl has not yet determined the file size */
 					if (total == "0.0")
 						return false;


### PR DESCRIPTION
Dear Genodians,

I have noticed a small issue where a failed `fetchurl` request would result in attempted package verification instead of correctly signalling a failed download. This does not seem to happen on all platforms. I believe this is a bug and this should fix it.