### PR TITLE
remove duplicates for libs to visit during make

### DIFF
--- a/repos/base/mk/dep_lib.mk
+++ b/repos/base/mk/dep_lib.mk
@@ -135,14 +135,12 @@ ifneq ($(DEP_MISSING_PORTS),)
 	@(echo "MISSING_PORTS += $(DEP_MISSING_PORTS)"; \
 	  echo "") >> $(LIB_DEP_FILE)
 endif
-	@for i in $(LIBS_TO_VISIT); do \
-	  $(MAKE) $(VERBOSE_DIR) -f $(BASE_DIR)/mk/dep_lib.mk REP_DIR=$(REP_DIR) LIB=$$i; done
 ifneq ($(LIBS),)
-	@(echo "$(DEP_A_VAR_NAME)  = $(foreach l,$(LIBS),\$${ARCHIVE_NAME($l)} \$$(DEP_A_$l))"; \
-	  echo "$(DEP_SO_VAR_NAME) = $(foreach l,$(LIBS),\$${SO_NAME($l)} \$$(DEP_SO_$l))"; \
+	@(echo "$(DEP_A_VAR_NAME)  = $(foreach l,$(call uniqL,$(LIBS),$(LIB)),\$${ARCHIVE_NAME($l)} \$$(DEP_A_$l))"; \
+	  echo "$(DEP_SO_VAR_NAME) = $(foreach l,$(call uniqL,$(LIBS),$(LIB)),\$${SO_NAME($l)} \$$(DEP_SO_$l))"; \
 	  echo "") >> $(LIB_DEP_FILE)
 endif
-	@(echo "$(LIB).lib: check_ports $(addsuffix .lib,$(LIBS))"; \
+	@(echo "$(LIB).lib: check_ports $(addsuffix .lib,$(call uniqL,$(LIBS),$(LIB)))"; \
 	  echo "	@\$$(MKDIR) -p \$$(LIB_CACHE_DIR)/$(LIB)"; \
 	  echo "	\$$(VERBOSE_MK)\$$(MAKE) $(VERBOSE_DIR) -C \$$(LIB_CACHE_DIR)/$(LIB) -f \$$(BASE_DIR)/mk/lib.mk \\"; \
 	  echo "	     REP_DIR=$(REP_DIR) \\"; \
@@ -163,4 +161,5 @@ else
 	@(echo "ARCHIVE_NAME($(LIB)) := $(LIB).lib.a"; \
 	  echo "") >> $(LIB_DEP_FILE)
 endif
-
+	@for i in $(call uniq,$(LIBS_TO_VISIT)); do \
+	  $(MAKE) $(VERBOSE_DIR) -f $(BASE_DIR)/mk/dep_lib.mk REP_DIR=$(REP_DIR) LIB=$$i; done

--- a/repos/base/mk/dep_prg.mk
+++ b/repos/base/mk/dep_prg.mk
@@ -80,7 +80,7 @@ ifneq ($(DEP_MISSING_PORTS),)
 	@(echo "MISSING_PORTS += $(DEP_MISSING_PORTS)"; \
 	  echo "") >> $(LIB_DEP_FILE)
 endif
-	@(echo "$(TARGET).prg: check_ports $(addsuffix .lib,$(LIBS))"; \
+	@(echo "$(TARGET).prg: check_ports $(addsuffix .lib,$(call uniqL,$(LIBS),$(LIB)))"; \
 	  echo "	@\$$(MKDIR) -p $(PRG_REL_DIR)"; \
 	  echo "	\$$(VERBOSE_MK)\$$(MAKE) $(VERBOSE_DIR) -C $(PRG_REL_DIR) -f \$$(BASE_DIR)/mk/prg.mk \\"; \
 	  echo "	     REP_DIR=$(REP_DIR) \\"; \

--- a/repos/base/mk/util.inc
+++ b/repos/base/mk/util.inc
@@ -69,3 +69,10 @@ select_from_ports = $(call _checked_port_dir,$1)
 else
 select_from_ports = $(REP_DIR)
 endif
+
+#
+# uniq:  remove dublicates from string keeping order
+# uniqL: remove dublicates and one additional word (2-d parameter) from string keeping order
+#
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+uniqL = $(filter-out $2,$(call uniq,$1))


### PR DESCRIPTION
I found a strange problem (use make 4.1). After some long work (which does not involve genode build system but compile code in build dir) it start to generate wrong libdeps file: some generated variables like DEP_A_base-nova-common refer to itself, directly or indirectly. Seems that this is because of LIBS variable somehow start to be modified from "bottom" recursive make invocation (still dont understand what is a trigger: I try to remove libdeps/progress.log from build, check shell environment variables - but this does not helps).
This is not a first time - every last years advances to new version works for some time for me, and then hit this unfixable problem forcing me to make another clean installation.

I make small patch which remove dup LIBS entries as well as LIB which should be build in invocation.
Seems that this could improve build performance (do not call unneeded recursive make invocations which goto already_visited target)