### PR TITLE
Update hello_tutorial, fix #5291

### DIFF
--- a/repos/hello_tutorial/doc/hello_tutorial.txt
+++ b/repos/hello_tutorial/doc/hello_tutorial.txt
@@ -193,6 +193,7 @@ the applications as a class called 'Main' with its constructor taking the
 component's environment as argument.
 
 !#include <base/component.h>
+!#include <base/heap.h>
 !
 !namespace Hello { struct Main; }
 !
@@ -257,7 +258,7 @@ entry to init's 'config' file, which is located at 'build/bin/config'.
 !   </default-route>
 !   <default caps="60"/>
 !   <start name="hello_server">
-!     <resource name="RAM" quantum="1M"/>
+!     <resource name="RAM" quantum="10M"/>
 !     <provides> <service name="Hello"/> </provides>
 !   </start>
 ! </config>
@@ -394,7 +395,7 @@ Add a 'target.mk' file with the following content to 'src/hello/client/':
 Extend your init _config_ as follows to also start the hello-client component:
 
 ! <start name="hello_client">
-!   <resource name="RAM" quantum="1M"/>
+!   <resource name="RAM" quantum="10M"/>
 ! </start>
 
 
@@ -407,7 +408,7 @@ script, which can be executed directly from within your build directory.
 A run script for the hello client-server scenario should be placed
 at the _run/hello.run_ and look as follows:
 
-!build { core init hello }
+!build { core lib/ld init hello }
 !
 !create_boot_directory
 !
@@ -415,21 +416,24 @@ at the _run/hello.run_ and look as follows:
 !<config>
 !  <parent-provides>
 !    <service name="LOG"/>
+!    <service name="PD"/>
+!    <service name="CPU"/>
+!    <service name="ROM"/>
 !  </parent-provides>
 !  <default-route>
 !    <any-service> <parent/> <any-child/> </any-service>
 !  </default-route>
 !  <default caps="60"/>
 !  <start name="hello_server">
-!    <resource name="RAM" quantum="1M"/>
+!    <resource name="RAM" quantum="10M"/>
 !    <provides> <service name="Hello"/> </provides>
 !  </start>
 !  <start name="hello_client">
-!    <resource name="RAM" quantum="1M"/>
+!    <resource name="RAM" quantum="10M"/>
 !  </start>
 !</config>}
 !
-!build_boot_image { core ld.lib.so init hello_client hello_server }
+!build_boot_image [build_artifacts]
 !
 !append qemu_args " -nographic "
 !

--- a/repos/hello_tutorial/doc/hello_tutorial.txt
+++ b/repos/hello_tutorial/doc/hello_tutorial.txt
@@ -258,7 +258,7 @@ entry to init's 'config' file, which is located at 'build/bin/config'.
 !   </default-route>
 !   <default caps="60"/>
 !   <start name="hello_server">
-!     <resource name="RAM" quantum="10M"/>
+!     <resource name="RAM" quantum="1M"/>
 !     <provides> <service name="Hello"/> </provides>
 !   </start>
 ! </config>
@@ -395,7 +395,7 @@ Add a 'target.mk' file with the following content to 'src/hello/client/':
 Extend your init _config_ as follows to also start the hello-client component:
 
 ! <start name="hello_client">
-!   <resource name="RAM" quantum="10M"/>
+!   <resource name="RAM" quantum="1M"/>
 ! </start>
 
 
@@ -425,11 +425,11 @@ at the _run/hello.run_ and look as follows:
 !  </default-route>
 !  <default caps="60"/>
 !  <start name="hello_server">
-!    <resource name="RAM" quantum="10M"/>
+!    <resource name="RAM" quantum="1M"/>
 !    <provides> <service name="Hello"/> </provides>
 !  </start>
 !  <start name="hello_client">
-!    <resource name="RAM" quantum="10M"/>
+!    <resource name="RAM" quantum="1M"/>
 !  </start>
 !</config>}
 !

--- a/repos/hello_tutorial/run/hello.run
+++ b/repos/hello_tutorial/run/hello.run
@@ -23,11 +23,11 @@ install_config {
 	</default-route>
 	<default caps="60"/>
 	<start name="hello_server">
-		<resource name="RAM" quantum="10M"/>
+		<resource name="RAM" quantum="1M"/>
 		<provides> <service name="Hello"/> </provides>
 	</start>
 	<start name="hello_client">
-		<resource name="RAM" quantum="10M"/>
+		<resource name="RAM" quantum="1M"/>
 	</start>
 </config>}
 

--- a/repos/hello_tutorial/run/hello.run
+++ b/repos/hello_tutorial/run/hello.run
@@ -23,11 +23,11 @@ install_config {
 	</default-route>
 	<default caps="60"/>
 	<start name="hello_server">
-		<resource name="RAM" quantum="1M"/>
+		<resource name="RAM" quantum="10M"/>
 		<provides> <service name="Hello"/> </provides>
 	</start>
 	<start name="hello_client">
-		<resource name="RAM" quantum="1M"/>
+		<resource name="RAM" quantum="10M"/>
 	</start>
 </config>}
 


### PR DESCRIPTION
Bring the docs up to date with the current run definition at https://github.com/genodelabs/genode/blob/master/repos/hello_tutorial/run/hello.run as well as changes to the imports of https://github.com/genodelabs/genode/blob/master/repos/hello_tutorial/src/hello/server/main.cc