### PR TITLE
fb_sdl: SDL2/3 compatability conversion

### DIFF
--- a/repos/os/src/driver/framebuffer/sdl/convert_keycode.h
+++ b/repos/os/src/driver/framebuffer/sdl/convert_keycode.h
@@ -33,7 +33,11 @@ static inline Input::Keycode convert_keycode(int sdl_keycode)
 	case SDLK_PAUSE:        return KEY_PAUSE;
 	case SDLK_ESCAPE:       return KEY_ESC;
 	case SDLK_SPACE:        return KEY_SPACE;
+	#ifdef SDL3
+	case SDLK_APOSTROPHE:   return KEY_APOSTROPHE;
+	#else
 	case SDLK_QUOTE:        return KEY_APOSTROPHE;
+	#endif
 	case SDLK_HASH:         return KEY_APOSTROPHE;
 	case SDLK_COMMA:        return KEY_COMMA;
 	case SDLK_MINUS:        return KEY_MINUS;
@@ -56,6 +60,35 @@ static inline Input::Keycode convert_keycode(int sdl_keycode)
 	case SDLK_LEFTBRACKET:  return KEY_LEFTBRACE;
 	case SDLK_BACKSLASH:    return KEY_BACKSLASH;
 	case SDLK_RIGHTBRACKET: return KEY_RIGHTBRACE;
+	#ifdef SDL3
+	case SDLK_GRAVE:        return KEY_GRAVE;
+	case SDLK_A:            return KEY_A;
+	case SDLK_B:            return KEY_B;
+	case SDLK_C:            return KEY_C;
+	case SDLK_D:            return KEY_D;
+	case SDLK_E:            return KEY_E;
+	case SDLK_F:            return KEY_F;
+	case SDLK_G:            return KEY_G;
+	case SDLK_H:            return KEY_H;
+	case SDLK_I:            return KEY_I;
+	case SDLK_J:            return KEY_J;
+	case SDLK_K:            return KEY_K;
+	case SDLK_L:            return KEY_L;
+	case SDLK_M:            return KEY_M;
+	case SDLK_N:            return KEY_N;
+	case SDLK_O:            return KEY_O;
+	case SDLK_P:            return KEY_P;
+	case SDLK_Q:            return KEY_Q;
+	case SDLK_R:            return KEY_R;
+	case SDLK_S:            return KEY_S;
+	case SDLK_T:            return KEY_T;
+	case SDLK_U:            return KEY_U;
+	case SDLK_V:            return KEY_V;
+	case SDLK_W:            return KEY_W;
+	case SDLK_X:            return KEY_X;
+	case SDLK_Y:            return KEY_Y;
+	case SDLK_Z:            return KEY_Z;
+	#else
 	case SDLK_BACKQUOTE:    return KEY_GRAVE;
 	case SDLK_a:            return KEY_A;
 	case SDLK_b:            return KEY_B;
@@ -83,6 +116,7 @@ static inline Input::Keycode convert_keycode(int sdl_keycode)
 	case SDLK_x:            return KEY_X;
 	case SDLK_y:            return KEY_Y;
 	case SDLK_z:            return KEY_Z;
+	#endif
 	case SDLK_DELETE:       return KEY_DELETE;
 
 	/* arrows + home/end pad */

--- a/repos/os/src/driver/framebuffer/sdl/sdl2.h
+++ b/repos/os/src/driver/framebuffer/sdl/sdl2.h
@@ -1,0 +1,112 @@
+/*
+ * \brief  SDL2 layer for the SDL implementation of the Genode framebuffer
+ * \author Norman Feske
+ * \author Christian Helmuth
+ * \date   2026-01-07
+ */
+
+/*
+ * Copyright (C) 2006-2024 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU Affero General Public License version 3.
+ */
+
+#ifndef _DRIVERS__FRAMEBUFFER__SPEC__SDL2__SDL_H_
+#define _DRIVERS__FRAMEBUFFER__SPEC__SDL2__SDL_H_
+
+/* Linux includes */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#pragma GCC diagnostic ignored "-Wnarrowing"        /* arm_neon.h */
+#pragma GCC diagnostic ignored "-Wunused-parameter" /* arm_neon.h */
+#pragma GCC diagnostic ignored "-Wfloat-conversion" /* arm_neon.h */
+#include <SDL2/SDL.h>
+#pragma GCC diagnostic pop
+
+
+namespace Fb_sdl {
+
+using MousePosition = int;
+
+#define SDL_EVENT_USER SDL_USEREVENT
+#define SDL_EVENT_MOUSE_MOTION SDL_MOUSEMOTION
+#define SDL_EVENT_KEY_UP SDL_KEYUP
+#define SDL_EVENT_KEY_DOWN SDL_KEYDOWN
+#define SDL_EVENT_MOUSE_BUTTON_DOWN SDL_MOUSEBUTTONDOWN
+#define SDL_EVENT_MOUSE_BUTTON_UP SDL_MOUSEBUTTONUP
+#define SDL_EVENT_MOUSE_WHEEL SDL_MOUSEWHEEL
+
+static inline bool is_window_event(const SDL_Event& event)
+{
+	return event.type == SDL_WINDOWEVENT;
+}
+
+static inline bool is_window_resized_event(const SDL_Event& event)
+{
+	return event.window.event == SDL_WINDOWEVENT_RESIZED;
+}
+
+static inline bool InitSDL()
+{
+	if(SDL_Init(SDL_INIT_VIDEO) < 0) {
+		return false;
+	}
+	SDL_ShowCursor(0);
+	return true;
+}
+
+static inline SDL_Window* CreateWindow(const char* title, int width, int height, int window_flags)
+{
+	SDL_Window* const window_ptr = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+	                                                width, height, window_flags);
+	SDL_SetWindowResizable(window_ptr, SDL_TRUE);
+	return window_ptr;
+}
+
+static inline Uint32 GetTicks()
+{
+	return SDL_GetTicks();
+}
+
+static inline SDL_Surface* CreateSurface(int width, int height)
+{
+	unsigned const flags      = 0;
+	unsigned const bpp        = 32;
+	unsigned const red_mask   = 0x00FF0000;
+	unsigned const green_mask = 0x0000FF00;
+	unsigned const blue_mask  = 0x000000FF;
+	unsigned const alpha_mask = 0xFF000000;
+	return SDL_CreateRGBSurface(flags, width, height , bpp,
+	                            red_mask, green_mask, blue_mask, alpha_mask);
+}
+
+static inline SDL_Renderer* CreateRenderer(SDL_Window* const window_ptr)
+{
+	int const index = -1;
+	unsigned const renderer_flags = SDL_RENDERER_SOFTWARE;
+	SDL_Renderer *renderer_ptr = SDL_CreateRenderer(window_ptr, index, renderer_flags);
+	return renderer_ptr;
+}
+
+static inline SDL_Texture* CreateTexture(SDL_Renderer* const renderer_ptr, int width, int height)
+{
+	return SDL_CreateTexture(renderer_ptr, SDL_PIXELFORMAT_ARGB8888,
+	                         SDL_TEXTUREACCESS_STREAMING,
+	                         width, height);
+}
+
+static inline void RenderCopy(SDL_Renderer* renderer, SDL_Texture* texture,
+                              const SDL_Rect* src, const SDL_Rect* dst)
+{
+	SDL_RenderCopy(renderer, texture, src, dst);
+}
+
+static inline void FreeSurface(SDL_Surface* surface) {
+	SDL_FreeSurface(surface);
+}
+
+}
+
+#endif /* _DRIVERS__FRAMEBUFFER__SPEC__SDL2__SDL_H_ */

--- a/repos/os/src/driver/framebuffer/sdl/sdl3.h
+++ b/repos/os/src/driver/framebuffer/sdl/sdl3.h
@@ -1,0 +1,108 @@
+/*
+ * \brief  SDL3-to-2 compability layer for the SDL implementation of the Genode framebuffer
+ * \author Norman Feske
+ * \author Christian Helmuth
+ * \date   2026-01-07
+ */
+
+/*
+ * Copyright (C) 2006-2024 Genode Labs GmbH
+ *
+ * This file is part of the Genode OS framework, which is distributed
+ * under the terms of the GNU Affero General Public License version 3.
+ */
+
+#ifndef _DRIVERS__FRAMEBUFFER__SPEC__SDL3__SDL_H_
+#define _DRIVERS__FRAMEBUFFER__SPEC__SDL3__SDL_H_
+
+/* Linux includes */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#pragma GCC diagnostic ignored "-Wnarrowing"        /* arm_neon.h */
+#pragma GCC diagnostic ignored "-Wunused-parameter" /* arm_neon.h */
+#pragma GCC diagnostic ignored "-Wfloat-conversion" /* arm_neon.h */
+#include <SDL3/SDL.h>
+#include <math.h>
+#undef SDL_TRUE
+#define SDL_TRUE true
+#undef SDL_FALSE
+#define SDL_FALSE false
+#pragma GCC diagnostic pop
+
+
+namespace Fb_sdl {
+
+using MousePosition = float;
+
+static inline bool is_window_event(const SDL_Event& event)
+{
+	return event.type >= SDL_EVENT_WINDOW_FIRST && event.type <= SDL_EVENT_WINDOW_LAST;
+}
+
+static inline bool is_window_resized_event(const SDL_Event& event)
+{
+	return event.type == SDL_EVENT_WINDOW_RESIZED;
+}
+
+static inline bool InitSDL()
+{
+	if(!SDL_Init(SDL_INIT_VIDEO)) {
+		return false;
+	}
+	SDL_HideCursor();
+	return true;
+}
+
+static inline SDL_Window* CreateWindow(const char* title, int width, int height, int window_flags)
+{
+	SDL_Window* const window_ptr = SDL_CreateWindow(title, width, height, window_flags);
+	SDL_SetWindowResizable(window_ptr, true);
+	return window_ptr;
+}
+
+static inline Uint32 GetTicks()
+{
+	return static_cast<Uint32>(SDL_GetTicks());
+}
+
+static inline SDL_Surface* CreateSurface(int width, int height)
+{
+	unsigned const bpp        = 32;
+	unsigned const red_mask   = 0x00FF0000;
+	unsigned const green_mask = 0x0000FF00;
+	unsigned const blue_mask  = 0x000000FF;
+	unsigned const alpha_mask = 0xFF000000;
+	auto format = SDL_GetPixelFormatForMasks(bpp, red_mask, green_mask, blue_mask, alpha_mask);
+	return SDL_CreateSurface(width, height, format);
+}
+
+static inline SDL_Renderer* CreateRenderer(SDL_Window* const window_ptr)
+{
+	return SDL_CreateRenderer(window_ptr, "software");
+}
+
+static inline SDL_Texture* CreateTexture(SDL_Renderer* const renderer_ptr, int width, int height)
+{
+	return SDL_CreateTexture(renderer_ptr, SDL_PIXELFORMAT_XRGB8888,
+	                         SDL_TEXTUREACCESS_STREAMING,
+	                         width, height);
+}
+
+static inline void RenderCopy(SDL_Renderer* renderer, SDL_Texture* texture,
+                              const SDL_Rect* src, const SDL_Rect* dst)
+{
+	SDL_FRect fsrc, fdst;
+	SDL_RectToFRect(src, &fsrc);
+	SDL_RectToFRect(dst, &fdst);
+	SDL_RenderTexture(renderer, texture, &fsrc, &fdst);
+}
+
+static inline void FreeSurface(SDL_Surface* surface)
+{
+	SDL_DestroySurface(surface);
+}
+
+}
+
+#endif /* _DRIVERS__FRAMEBUFFER__SPEC__SDL__SDL_H_ */

--- a/repos/os/src/driver/framebuffer/sdl/target.mk
+++ b/repos/os/src/driver/framebuffer/sdl/target.mk
@@ -2,8 +2,17 @@ TARGET   = fb_sdl
 LIBS     = lx_hybrid blit
 REQUIRES = linux
 SRC_CC   = main.cc
-LX_LIBS  = sdl2
-INC_DIR += $(PRG_DIR) /usr/include/SDL2
+SDL_INC  = /usr/include/SDL2
+SDL_LIB  = sdl2
+
+ifeq ($(GENODE_FB_SDL_VERSION),3)
+CC_OPT += -DSDL3
+SDL_INC = /usr/include/SDL3
+SDL_LIB = sdl3
+endif
+
+LX_LIBS  = $(SDL_LIB)
+INC_DIR += $(PRG_DIR) $(SDL_INC)
 
 # accept conversion warnings caused by libgcc's include/arm_neon.h
 CC_OPT  += -Wno-error=narrowing \


### PR DESCRIPTION
Converts the SDL2 fb_sdl codebase to SDL3 via an sdl2/sdl3.h shim.

Confirmed working on stock SDL2 Ubuntu LTS 24.04. Confirmed working
on manually compiled SDL3 on Ubuntu LTS 24.04. make run/demo
BOARD=linux KERNEL=linux runs and is visually correct.