### PR TITLE
AHCI: Resolve port initialization conflict on boot vs S4 resume

### DIFF
--- a/repos/os/src/driver/ahci/ahci.h
+++ b/repos/os/src/driver/ahci/ahci.h
@@ -898,13 +898,31 @@ struct Ahci::Port : private Port_base
 		reinit();
 	}
 
-	void reinit()
+	void reinit(bool is_resume = false)
 	{
 		_with_port_mmio([&](Port_mmio &mmio) {
-			reset(mmio);
 
-			if (!enable(mmio))
-				throw 1;
+			if (!enable(mmio)) {
+				/*
+				 * No SATA link. On boot or S3 resume the link is already
+				 * established by the BIOS / powered controller, so a missing
+				 * link means the port is empty.
+				 */
+				if (!is_resume)
+					throw 1;
+
+				/*
+				 * On S4 resume (full power loss) all port registers reset to
+				 * zero including PxSSTS, so the link must be re-established.
+				 * Cmd::St and FRE are guaranteed 0 after power loss, so
+				 * reset() is safe and setup_memory() inside init() will find
+				 * FR=0 immediately.
+				 */
+				reset(mmio);
+
+				if (!enable(mmio))
+					throw 1;
+			}
 
 			stop(mmio);
 

--- a/repos/os/src/driver/ahci/main.cc
+++ b/repos/os/src/driver/ahci/main.cc
@@ -160,7 +160,7 @@ class Ahci::Driver : Noncopyable
 				/* re-start request handling of client sessions */
 				for_each_port([&](auto &port, auto const index, auto) {
 					try {
-						port.reinit();
+						port.reinit(true);
 						port.stop_processing = false;
 						_dispatch.session(index);
 					} catch (...) {


### PR DESCRIPTION
This PR is vibe-coded with thorough supervision and sanity check.
Though I'm not an expert in C++ nor in drivers development.

Here is the summary of the reasoning behind the changes produced by AI:

> On systems with an IOMMU, SATA ports were logged as "off (ATA)" at boot
> despite the BIOS having successfully initialized the devices.
> 
> Root cause
> ----------
> Port::reinit() unconditionally called reset() (COMRESET via PxSCTL.Det)
> before enable() and before setup_memory() had mapped a Genode-owned FIS
> receive buffer into PxFB.
> 
> At that point PxFB still held the BIOS-allocated physical address and FRE
> (FIS Receive Enable) was left enabled by the BIOS. The device responded to
> COMRESET by posting a D2H Register FIS. The HBA attempted a DMA write to
> the BIOS address, which the IOMMU blocked. As a result FR (FIS Receive
> Running) never cleared. The subsequent setup_memory() → wait_for(FR=0)
> timed out with Polling_timeout, which propagated out of _scan_ports and
> left the port disabled.
> 
> Fix
> ---
> Move the COMRESET out of the unconditional preamble and instead call
> enable() first:
> 
> - On boot and S3 resume the SATA link is already established by the BIOS /
>   powered controller. enable() succeeds immediately and no COMRESET is
>   needed before init().
> 
> - On S4 resume (full power loss) all port registers including PxSSTS reset
>   to zero, so enable() returns false. In that case reset() is issued to
>   re-establish the link. After S4, Cmd::St and FRE are guaranteed 0 by
>   power loss, so the COMRESET cannot trigger an IOMMU-blocked DMA, and
>   setup_memory() inside the subsequent init() will find FR=0 immediately.
> 
> The is_resume parameter (defaulting to false) distinguishes the two
> failure meanings of enable() returning false: an empty port at boot (throw
> immediately, DMA registers never touched) versus a link-down condition at
> S4 resume (reset and retry).
> 
> The resume call site in main.cc is updated to pass is_resume=true.

Tested on my system building Sculpt from the current `master` branch and now I have access to all of my drives.
![20260413_112232](https://github.com/user-attachments/assets/7f98c8d3-7bdf-4535-ac1a-669956765883)
![20260413_112216](https://github.com/user-attachments/assets/b43d0108-fda8-460c-8200-670b4dad7bcc)